### PR TITLE
Add (initial) support for lowering FIRRTL wire to RTL wire. 

### DIFF
--- a/lib/Dialect/FIRRTL/LowerToRTL.cpp
+++ b/lib/Dialect/FIRRTL/LowerToRTL.cpp
@@ -105,9 +105,9 @@ static LogicalResult lower(firrtl::WireOp op, ArrayRef<Value> operands,
 
     if (auto intType = resultType.getValue().dyn_cast<IntegerType>()) {
       rewriter.replaceOpWithNewOp<rtl::WireOp>(op, intType, op.nameAttr());
-    }
     // TODO: Add support for vectors in RTL. The below code to handle FIRRTL
     // vectors is not a solution.
+    }
     else if (auto fvType = resFirType.dyn_cast<FVectorType>()) {
       unsigned numElems = fvType.getNumElements();
       auto elemType = RTLTypeConverter::convertType(fvType.getElementType());

--- a/lib/Dialect/FIRRTL/LowerToRTL.cpp
+++ b/lib/Dialect/FIRRTL/LowerToRTL.cpp
@@ -100,18 +100,12 @@ static LogicalResult lower(firrtl::ConstantOp op, ArrayRef<Value> operands,
 static LogicalResult lower(firrtl::WireOp op, ArrayRef<Value> operands,
                            ConversionPatternRewriter &rewriter) {
   auto resType = op.result().getType().cast<FIRRTLType>();
-  if (auto resultType = RTLTypeConverter::convertType(resType)) {
-
-    if (auto intType = resultType.getValue().dyn_cast<IntegerType>()) {
-      rewriter.replaceOpWithNewOp<rtl::WireOp>(op, intType, op.nameAttr());
-      return success();
-    } else {
-      op.emitError("Unsupported type of FIRRTL wire.");
-      return failure();
-    }
-  }
-
-  return failure();
+  auto resultType = RTLTypeConverter::convertType(resType);
+  if (!resultType)
+    return failure();
+  rewriter.replaceOpWithNewOp<rtl::WireOp>(op, resultType.getValue(),
+                                           op.nameAttr());
+  return success();
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/firrtl/lower-to-rtl.mlir
+++ b/test/firrtl/lower-to-rtl.mlir
@@ -46,10 +46,10 @@
     // CHECK-NEXT: %11 = rtl.wire : i2
     firrtl.wire : !firrtl.uint<2>
 
-    // CHECK-NEXT: %12 = firrtl.wire : !firrtl.vector<uint<1>, 13>
+    // CHECK-NEXT: %12 = rtl.wire : !firrtl.vector<uint<1>, 13>
     %_t_2 = firrtl.wire : !firrtl.vector<uint<1>, 13>
 
-    // CHECK-NEXT: %13 = firrtl.wire : !firrtl.vector<uint<2>, 13>
+    // CHECK-NEXT: %13 = rtl.wire : !firrtl.vector<uint<2>, 13>
     %_t_3 = firrtl.wire : !firrtl.vector<uint<2>, 13>
   }
 }

--- a/test/firrtl/lower-to-rtl.mlir
+++ b/test/firrtl/lower-to-rtl.mlir
@@ -45,5 +45,11 @@
 
     // CHECK-NEXT: %11 = rtl.wire : i2
     firrtl.wire : !firrtl.uint<2>
+
+    // CHECK-NEXT: %12 = rtl.wire : i13
+    %_t_2 = firrtl.wire : !firrtl.vector<uint<1>, 13>
+
+    // CHECK-NEXT: %13 = rtl.wire : i26
+    %_t_3 = firrtl.wire : !firrtl.vector<uint<2>, 13>
   }
 }

--- a/test/firrtl/lower-to-rtl.mlir
+++ b/test/firrtl/lower-to-rtl.mlir
@@ -46,10 +46,10 @@
     // CHECK-NEXT: %11 = rtl.wire : i2
     firrtl.wire : !firrtl.uint<2>
 
-    // CHECK-NEXT: %12 = rtl.wire : i13
+    // CHECK-NEXT: %12 = firrtl.wire : !firrtl.vector<uint<1>, 13>
     %_t_2 = firrtl.wire : !firrtl.vector<uint<1>, 13>
 
-    // CHECK-NEXT: %13 = rtl.wire : i26
+    // CHECK-NEXT: %13 = firrtl.wire : !firrtl.vector<uint<2>, 13>
     %_t_3 = firrtl.wire : !firrtl.vector<uint<2>, 13>
   }
 }

--- a/test/firrtl/lower-to-rtl.mlir
+++ b/test/firrtl/lower-to-rtl.mlir
@@ -39,5 +39,11 @@
 
     // CHECK-NEXT: firrtl.connect %out1, %8 : !firrtl.flip<uint<4>>, i4
     firrtl.connect %out1, %5 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+
+    // CHECK-NEXT: %10 = rtl.wire {name = "test-name"} : i4
+    firrtl.wire {name = "test-name"} : !firrtl.uint<4>
+
+    // CHECK-NEXT: %11 = rtl.wire : i2
+    firrtl.wire : !firrtl.uint<2>
   }
 }

--- a/test/rtl/basic.mlir
+++ b/test/rtl/basic.mlir
@@ -10,6 +10,7 @@ func @test1(%arg0: i3) -> i50 {
 
   %aa = rtl.concat %a : (i12) -> i12
   %result = rtl.concat %aa, %b, %c, %d, %e : (i12, i12, i12, i7, i7) -> i50
+  %x = rtl.wire : i2
   return %result : i50
 }
 
@@ -21,5 +22,6 @@ func @test1(%arg0: i3) -> i50 {
 // CHECK-NEXT:    %3 = rtl.zext %arg0 : i3, i7
 // CHECK-NEXT:    %4 = rtl.concat %c42_i12 : (i12) -> i12
 // CHECK-NEXT:    %5 = rtl.concat %4, %0, %1, %2, %3 : (i12, i12, i12, i7, i7) -> i50
+// CHECK-NEXT:    %6 = rtl.wire : i2
 // CHECK-NEXT:    return %5 : i50
 // CHECK-NEXT:  }


### PR DESCRIPTION
Addresses #7. Lowers FIRRTL wires to RTL wires. FIRRTL wire vectors are flattened in a less-than-ideal way, which has been marked as a TODO. My impression is that more elegant lowering requires adding vector support, which I will tack on in a future commit. 

Probably not ready to merge yet, due to the wire vector lowering.