### PR TITLE
[handshake] add mlir-headers dependencies

### DIFF
--- a/lib/Conversion/StandardToHandshake/CMakeLists.txt
+++ b/lib/Conversion/StandardToHandshake/CMakeLists.txt
@@ -4,7 +4,7 @@ add_mlir_library(MLIRStandardToHandshake
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/StandardToHandshake
 
-  LINK_LIBS
+  LINK_LIBS PUBLIC
   MLIRIR
   MLIRPass
   MLIRStandardOps

--- a/lib/Dialect/Handshake/CMakeLists.txt
+++ b/lib/Dialect/Handshake/CMakeLists.txt
@@ -11,7 +11,7 @@ add_mlir_dialect_library(MLIRHandshakeOps
   ${PROJECT_SOURCE_DIR}/include
   ${PROJECT_BINARY_DIR}/include
 
-  LINK_LIBS
+  LINK_LIBS PUBLIC
   MLIRStandardOps
   MLIRIR
 


### PR DESCRIPTION
This shouldn't strictly be necessary, but it seems the CI build is
still unhappy with the dependencies.

Also testing pull requests for CI