### PR TITLE
[llvm] Update

### DIFF
--- a/lib/Dialect/FIRRTL/LowerToRTL.cpp
+++ b/lib/Dialect/FIRRTL/LowerToRTL.cpp
@@ -247,8 +247,7 @@ struct FIRRTLLowering : public LowerFIRRTLToRTLBase<FIRRTLLowering> {
 
     RTLConversionTarget target(getContext());
     RTLTypeConverter typeConverter;
-    if (failed(applyPartialConversion(getOperation(), target, patterns,
-                                      &typeConverter)))
+    if (failed(applyPartialConversion(getOperation(), target, patterns)))
       signalPassFailure();
   }
 };


### PR DESCRIPTION
This pulls in a new version of the RegionKindInterface proposal.
Also, there's an interface change in applyPartialConversion, which no
longer includes a Type Converter.  This doesn't seem to affect the
FIRRTL testcases, so I'm not sure if there is anything to fix here
beyond dropping the unnecessary converter.