### PR TITLE
[LLHD] Add extract field operations

### DIFF
--- a/include/circt/Dialect/LLHD/IR/ExtractOps.td
+++ b/include/circt/Dialect/LLHD/IR/ExtractOps.td
@@ -101,3 +101,118 @@ def LLHD_DextsOp : LLHD_Op<"dexts", [
     unsigned getTargetWidth() { return getLLHDTypeWidth(target().getType()); }
   }];
 }
+
+def LLHD_ExtfOp : LLHD_Op<"extf", [
+    NoSideEffect,
+    PredOpTrait<"'index' has to be smaller than the 'target' size",
+      CPred<"$index.cast<IntegerAttr>().getInt() < getTargetWidth()">>,
+    TypesMatchWith<"'result' type has to match type at 'index' of 'target', in "
+      "case 'target' is a singal, consider the underlying types of the 'target'"
+      " and 'result' signals",
+      "target", "result",
+      "($_self.isa<llhd::SigType>() "
+        "? llhd::SigType::get("
+          "getElementTypeAtIndex($index.cast<IntegerAttr>().getInt())) "
+        ": getElementTypeAtIndex($index.cast<IntegerAttr>().getInt()))">
+  ]> {
+  let summary = "Extract an element from a vector or tuple";
+  let description = [{
+    The `llhd.extf` operation allows access to an element of the `$target`
+    operand. The `$index` attribute defines the index of the element to extract.
+    If `%target` is a signal, a new subsignal aliasing the field will be
+    returned.
+
+    Example:
+
+    ```mlir
+    %0 = constant dense<[1,2,3]> : vector<3xi8>
+    %1 = llhd.extf %0, 0 : vector<3xi8> -> i8
+
+    %2 = llhd.sig %0 : vector<3xi8>
+    %3 = llhd.extf %2, 0 : !llhd.sig<vector<3xi8>> -> !llhd.sig<i8>
+
+    %4 = llhd.const 8 : i16
+    %5 = llhd.tuple %0, %4 : tuple<vector<3xi8>, i16>
+    %6 = llhd.extf %5, 1 : tuple<vector<3xi8>, i16> -> i16
+    ```
+  }];
+
+  let arguments = (ins AnyTypeOf<[
+      AnyVector,
+      AnyTuple,
+      LLHD_SigType<[AnyVector, AnyTuple]>
+    ]>: $target,
+    IndexAttr: $index);
+
+  let results = (outs AnyType: $result);
+
+  let assemblyFormat = [{
+    $target `,` $index attr-dict `:` type($target) `->` type($result)
+  }];
+
+  let extraClassDeclaration = [{
+    unsigned getTargetWidth() { return getLLHDTypeWidth(target().getType()); };
+
+    Type getElementTypeAtIndex(unsigned index) {
+      Type targetType = target().getType();
+      if (auto sig = targetType.dyn_cast<llhd::SigType>())
+        targetType = sig.getUnderlyingType();
+      if (auto vec = targetType.dyn_cast<VectorType>())
+        return vec.getElementType();
+      return targetType.dyn_cast<TupleType>().getTypes()[index];
+    }
+  }];
+}
+
+def LLHD_DextfOp : LLHD_Op<"dextf", [
+  NoSideEffect,
+  TypesMatchWith<"'result' must be the element type of the 'target' vector, in "
+    "case 'target' is a signal of a vector, 'result' also is a signal of the "
+    "vector element type",
+    "target", "result",
+    "($_self.isa<llhd::SigType>() ? llhd::SigType::get(getElementType()) "
+                                 ": getElementType())">
+  ]> {
+  let summary = [{
+    Dynamically extract an element from a vector or signal of vector.
+  }];
+  let description = [{
+    The `llhd.dextf` operation allows to dynamically access an element of the
+    `$target` operand. The `$index` operand defines the index of the element to
+    extract. If `%target` is a signal, a new subsignal aliasing the element will
+    be returned.
+
+    Example:
+
+    ```mlir
+    %index = llhd.const 1 : i2
+
+    %0 = constant dense<[1,2,3]> : vector<3xi8>
+    %1 = llhd.dextf %0, %index : (vector<3xi8>, i2) -> i8
+
+    %2 = llhd.sig %0 : vector<3xi8>
+    %3 = llhd.dextf %2, %index : (!llhd.sig<vector<3xi8>>, i2) -> !llhd.sig<i8>
+    ```
+  }];
+
+  let arguments = (ins
+    AnyTypeOf<[AnyVector, LLHD_SigType<[AnyVector]>]>: $target,
+    AnySignlessInteger: $index);
+
+  let results = (outs AnyType: $result);
+
+  let assemblyFormat = [{
+    $target `,` $index attr-dict `:` functional-type(operands, results)
+  }];
+
+  let extraClassDeclaration = [{
+    unsigned getTargetWidth() { return getLLHDTypeWidth(target().getType()); }
+
+    Type getElementType() {
+      Type targetType = target().getType();
+      if (auto sig = targetType.dyn_cast<llhd::SigType>())
+        targetType = sig.getUnderlyingType();
+      return targetType.dyn_cast<VectorType>().getElementType();
+    }
+  }];
+}

--- a/include/circt/Dialect/LLHD/IR/ExtractOps.td
+++ b/include/circt/Dialect/LLHD/IR/ExtractOps.td
@@ -102,38 +102,41 @@ def LLHD_DextsOp : LLHD_Op<"dexts", [
   }];
 }
 
-def LLHD_ExtfOp : LLHD_Op<"extf", [
+def LLHD_ExtractElementOp : LLHD_Op<"extract_element", [
     NoSideEffect,
-    PredOpTrait<"'index' has to be smaller than the 'target' size",
+    PredOpTrait<"'index' has to be smaller than the width of the 'target' type",
       CPred<"$index.cast<IntegerAttr>().getInt() < getTargetWidth()">>,
-    TypesMatchWith<"'result' type has to match type at 'index' of 'target', in "
-      "case 'target' is a singal, consider the underlying types of the 'target'"
-      " and 'result' signals",
+    TypesMatchWith<
+      "'result' type must match the type of 'target' at position 'index', or "
+      "in case 'target' is a signal, it must be a signal of the underlying type"
+      " of 'target' at position 'index'",
       "target", "result",
       "($_self.isa<llhd::SigType>() "
         "? llhd::SigType::get("
           "getElementTypeAtIndex($index.cast<IntegerAttr>().getInt())) "
         ": getElementTypeAtIndex($index.cast<IntegerAttr>().getInt()))">
   ]> {
-  let summary = "Extract an element from a vector or tuple";
+  let summary = [{
+    Extract an element from a vector, tuple, or signal of a vector or tuple.
+  }];
   let description = [{
-    The `llhd.extf` operation allows access to an element of the `$target`
-    operand. The `$index` attribute defines the index of the element to extract.
-    If `%target` is a signal, a new subsignal aliasing the field will be
-    returned.
+    The `llhd.extract_element` operation allows access to an element of the
+    `$target` operand. The `$index` attribute defines the index of the element
+    to extract. If `%target` is a signal, a new subsignal aliasing the element
+    will be returned.
 
     Example:
 
     ```mlir
     %0 = constant dense<[1,2,3]> : vector<3xi8>
-    %1 = llhd.extf %0, 0 : vector<3xi8> -> i8
+    %1 = llhd.extract_element %0, 0 : vector<3xi8> -> i8
 
     %2 = llhd.sig %0 : vector<3xi8>
-    %3 = llhd.extf %2, 0 : !llhd.sig<vector<3xi8>> -> !llhd.sig<i8>
+    %3 = llhd.extract_element %2, 0 : !llhd.sig<vector<3xi8>> -> !llhd.sig<i8>
 
     %4 = llhd.const 8 : i16
     %5 = llhd.tuple %0, %4 : tuple<vector<3xi8>, i16>
-    %6 = llhd.extf %5, 1 : tuple<vector<3xi8>, i16> -> i16
+    %6 = llhd.extract_element %5, 1 : tuple<vector<3xi8>, i16> -> i16
     ```
   }];
 
@@ -164,7 +167,7 @@ def LLHD_ExtfOp : LLHD_Op<"extf", [
   }];
 }
 
-def LLHD_DextfOp : LLHD_Op<"dextf", [
+def LLHD_DynamicExtractElementOp : LLHD_Op<"dyn_extract_element", [
   NoSideEffect,
   TypesMatchWith<"'result' must be the element type of the 'target' vector, in "
     "case 'target' is a signal of a vector, 'result' also is a signal of the "
@@ -177,10 +180,10 @@ def LLHD_DextfOp : LLHD_Op<"dextf", [
     Dynamically extract an element from a vector or signal of vector.
   }];
   let description = [{
-    The `llhd.dextf` operation allows to dynamically access an element of the
-    `$target` operand. The `$index` operand defines the index of the element to
-    extract. If `%target` is a signal, a new subsignal aliasing the element will
-    be returned.
+    The `llhd.dyn_extract_element` operation allows to dynamically access an
+    element of the `$target` operand. The `$index` operand defines the index of
+    the element to extract. If `%target` is a signal, a new subsignal aliasing
+    the element will be returned.
 
     Example:
 
@@ -188,10 +191,11 @@ def LLHD_DextfOp : LLHD_Op<"dextf", [
     %index = llhd.const 1 : i2
 
     %0 = constant dense<[1,2,3]> : vector<3xi8>
-    %1 = llhd.dextf %0, %index : (vector<3xi8>, i2) -> i8
+    %1 = llhd.dyn_extract_element %0, %index : (vector<3xi8>, i2) -> i8
 
     %2 = llhd.sig %0 : vector<3xi8>
-    %3 = llhd.dextf %2, %index : (!llhd.sig<vector<3xi8>>, i2) -> !llhd.sig<i8>
+    %3 = llhd.dyn_extract_element %2, %index
+      : (!llhd.sig<vector<3xi8>>, i2) -> !llhd.sig<i8>
     ```
   }];
 

--- a/test/Dialect/LLHD/IR/ext.mlir
+++ b/test/Dialect/LLHD/IR/ext.mlir
@@ -92,6 +92,78 @@ func @dexts_vec(%v1 : vector<1xi1>, %v10 : vector<10xi1>, %i0 : i5, %i1 : i10) {
     return
 }
 
+// CHECK-LABEL: @extf_vectors
+// CHECK-SAME: %[[VEC1:.*]]: vector<1xi1>
+// CHECK-SAME: %[[VEC5:.*]]: vector<5xi32>
+func @extf_vectors(%vec1 : vector<1xi1>, %vec5 : vector<5xi32>) {
+    // CHECK-NEXT: %{{.*}} = llhd.extf %[[VEC1]], 0 : vector<1xi1> -> i1
+    %0 = llhd.extf %vec1, 0 : vector<1xi1> -> i1
+    // CHECK-NEXT: %{{.*}} = llhd.extf %[[VEC5]], 4 : vector<5xi32> -> i32
+    %1 = llhd.extf %vec5, 4 : vector<5xi32> -> i32
+
+    return
+}
+
+// CHECK-LABEL: @extf_tuples
+// CHECK-SAME: %[[TUP:.*]]: tuple<i1, i2, i3>
+func @extf_tuples(%tup : tuple<i1, i2, i3>) {
+    // CHECK-NEXT: %{{.*}} = llhd.extf %[[TUP]], 0 : tuple<i1, i2, i3> -> i1
+    %0 = llhd.extf %tup, 0 : tuple<i1, i2, i3> -> i1
+    // CHECK-NEXT: %{{.*}} = llhd.extf %[[TUP]], 2 : tuple<i1, i2, i3> -> i3
+    %1 = llhd.extf %tup, 2 : tuple<i1, i2, i3> -> i3
+
+    return
+}
+
+// CHECK-LABEL: @extf_signals_of_vectors
+// CHECK-SAME: %[[VEC1:.*]]: !llhd.sig<vector<1xi1>>
+// CHECK-SAME: %[[VEC5:.*]]: !llhd.sig<vector<5xi32>>
+func @extf_signals_of_vectors(%vec1 : !llhd.sig<vector<1xi1>>, %vec5 : !llhd.sig<vector<5xi32>>) {
+    // CHECK-NEXT: %{{.*}} = llhd.extf %[[VEC1]], 0 : !llhd.sig<vector<1xi1>> -> !llhd.sig<i1>
+    %0 = llhd.extf %vec1, 0 : !llhd.sig<vector<1xi1>> -> !llhd.sig<i1>
+    // CHECK-NEXT: %{{.*}} = llhd.extf %[[VEC5]], 4 : !llhd.sig<vector<5xi32>> -> !llhd.sig<i32>
+    %1 = llhd.extf %vec5, 4 : !llhd.sig<vector<5xi32>> -> !llhd.sig<i32>
+
+    return
+}
+
+// CHECK-LABEL: @extf_signals_of_tuples
+// CHECK-SAME: %[[TUP:.*]]: !llhd.sig<tuple<i1, i2, i3>>
+func @extf_signals_of_tuples(%tup : !llhd.sig<tuple<i1, i2, i3>>) {
+    // CHECK-NEXT: %{{.*}} = llhd.extf %[[TUP]], 0 : !llhd.sig<tuple<i1, i2, i3>> -> !llhd.sig<i1>
+    %0 = llhd.extf %tup, 0 : !llhd.sig<tuple<i1, i2, i3>> -> !llhd.sig<i1>
+    // CHECK-NEXT: %{{.*}} = llhd.extf %[[TUP]], 2 : !llhd.sig<tuple<i1, i2, i3>> -> !llhd.sig<i3>
+    %1 = llhd.extf %tup, 2 : !llhd.sig<tuple<i1, i2, i3>> -> !llhd.sig<i3>
+
+    return
+}
+
+// CHECK-LABEL: @dextf_vectors
+// CHECK-SAME: %[[INDEX:.*]]: i32
+// CHECK-SAME: %[[VEC1:.*]]: vector<1xi1>
+// CHECK-SAME: %[[VEC5:.*]]: vector<5xi32>
+func @dextf_vectors(%index : i32, %vec1 : vector<1xi1>, %vec5 : vector<5xi32>) {
+    // CHECK-NEXT: %{{.*}} = llhd.dextf %[[VEC1]], %[[INDEX]] : (vector<1xi1>, i32) -> i1
+    %0 = llhd.dextf %vec1, %index : (vector<1xi1>, i32) -> i1
+    // CHECK-NEXT: %{{.*}} = llhd.dextf %[[VEC5]], %[[INDEX]] : (vector<5xi32>, i32) -> i32
+    %1 = llhd.dextf %vec5, %index : (vector<5xi32>, i32) -> i32
+
+    return
+}
+
+// CHECK-LABEL: @dextf_signals_of_vectors
+// CHECK-SAME: %[[INDEX:.*]]: i32
+// CHECK-SAME: %[[VEC1:.*]]: !llhd.sig<vector<1xi1>>
+// CHECK-SAME: %[[VEC5:.*]]: !llhd.sig<vector<5xi32>>
+func @dextf_signals_of_vectors(%index : i32, %vec1 : !llhd.sig<vector<1xi1>>, %vec5 : !llhd.sig<vector<5xi32>>) {
+    // CHECK-NEXT: %{{.*}} = llhd.dextf %[[VEC1]], %[[INDEX]] : (!llhd.sig<vector<1xi1>>, i32) -> !llhd.sig<i1>
+    %0 = llhd.dextf %vec1, %index : (!llhd.sig<vector<1xi1>>, i32) -> !llhd.sig<i1>
+    // CHECK-NEXT: %{{.*}} = llhd.dextf %[[VEC5]], %[[INDEX]] : (!llhd.sig<vector<5xi32>>, i32) -> !llhd.sig<i32>
+    %1 = llhd.dextf %vec5, %index : (!llhd.sig<vector<5xi32>>, i32) -> !llhd.sig<i32>
+
+    return
+}
+
 // -----
 
 func @illegal_vector_to_signal(%vec : vector<3xi32>) {
@@ -214,6 +286,87 @@ func @dexts_illegal_out_too_wide(%c : i32, %i : i1) {
 func @dexts_illegal_vec_element_conversion(%c : vector<1xi1>, %i : i1) {
     // expected-error @+1 {{'llhd.dexts' op failed to verify that 'target' and 'result' types have to match apart from their width}}
     %0 = llhd.dexts %c, %i : (vector<1xi1>, i1) -> vector<1xi10>
+
+    return
+}
+
+// -----
+
+func @extf_vector_index_out_of_bounds(%vec : vector<3xi1>) {
+    // expected-error @+1 {{'index' has to be smaller than the 'target' size}}
+    %0 = llhd.extf %vec, 3 : vector<3xi1> -> i1
+
+    return
+}
+
+// -----
+
+func @extf_tuple_index_out_of_bounds(%tup : tuple<i1, i2, i3>) {
+    // expected-error @+1 {{'index' has to be smaller than the 'target' size}}
+    %0 = llhd.extf %tup, 3 : tuple<i1, i2, i3> -> i3
+
+    return
+}
+
+// -----
+
+func @extf_vector_type_mismatch(%vec : vector<3xi1>) {
+    // expected-error @+1 {{'result' type has to match type at 'index' of 'target', in case 'target' is a singal, consider the underlying types of the 'target' and 'result' signals}}
+    %0 = llhd.extf %vec, 0 : vector<3xi1> -> i2
+
+    return
+}
+
+// -----
+
+func @extf_tuple_type_mismatch(%tup : tuple<i1, i2, i3>) {
+    // expected-error @+1 {{'result' type has to match type at 'index' of 'target', in case 'target' is a singal, consider the underlying types of the 'target' and 'result' signals}}
+    %0 = llhd.extf %tup, 0 : tuple<i1, i2, i3> -> i2
+
+    return
+}
+
+// -----
+
+func @extf_signal_type_mismatch(%sig : !llhd.sig<tuple<i1, i2, i3>>) {
+    // expected-error @+1 {{'result' type has to match type at 'index' of 'target', in case 'target' is a singal, consider the underlying types of the 'target' and 'result' signals}}
+    %0 = llhd.extf %sig, 0 : !llhd.sig<tuple<i1, i2, i3>> -> !llhd.sig<i2>
+
+    return
+}
+
+// -----
+
+func @extf_illegal_signal_alias(%sig : !llhd.sig<tuple<i1, i2, i3>>) {
+    // expected-error @+1 {{'result' type has to match type at 'index' of 'target', in case 'target' is a singal, consider the underlying types of the 'target' and 'result' signals}}
+    %0 = llhd.extf %sig, 0 : !llhd.sig<tuple<i1, i2, i3>> -> i1
+
+    return
+}
+
+// -----
+
+func @dextf_vector_type_mismatch(%index : i2, %vec : vector<3xi1>) {
+    // expected-error @+1 {{'result' must be the element type of the 'target' vector, in case 'target' is a signal of a vector, 'result' also is a signal of the vector element type}}
+    %0 = llhd.dextf %vec, %index : (vector<3xi1>, i2) -> i2
+
+    return
+}
+
+// -----
+
+func @dextf_signal_type_mismatch(%index : i2, %sig : !llhd.sig<vector<3xi1>>) {
+    // expected-error @+1 {{'result' must be the element type of the 'target' vector, in case 'target' is a signal of a vector, 'result' also is a signal of the vector element type}}
+    %0 = llhd.dextf %sig, %index : (!llhd.sig<vector<3xi1>>, i2) -> !llhd.sig<i2>
+
+    return
+}
+
+// -----
+
+func @dextf_illegal_signal_alias(%index : i2, %sig : !llhd.sig<vector<3xi1>>) {
+    // expected-error @+1 {{'result' must be the element type of the 'target' vector, in case 'target' is a signal of a vector, 'result' also is a signal of the vector element type}}
+    %0 = llhd.dextf %sig, %index : (!llhd.sig<vector<3xi1>>, i2) -> i1
 
     return
 }

--- a/test/Dialect/LLHD/IR/extract.mlir
+++ b/test/Dialect/LLHD/IR/extract.mlir
@@ -92,74 +92,74 @@ func @dexts_vec(%v1 : vector<1xi1>, %v10 : vector<10xi1>, %i0 : i5, %i1 : i10) {
     return
 }
 
-// CHECK-LABEL: @extf_vectors
+// CHECK-LABEL: @extract_element_vectors
 // CHECK-SAME: %[[VEC1:.*]]: vector<1xi1>
 // CHECK-SAME: %[[VEC5:.*]]: vector<5xi32>
-func @extf_vectors(%vec1 : vector<1xi1>, %vec5 : vector<5xi32>) {
-    // CHECK-NEXT: %{{.*}} = llhd.extf %[[VEC1]], 0 : vector<1xi1> -> i1
-    %0 = llhd.extf %vec1, 0 : vector<1xi1> -> i1
-    // CHECK-NEXT: %{{.*}} = llhd.extf %[[VEC5]], 4 : vector<5xi32> -> i32
-    %1 = llhd.extf %vec5, 4 : vector<5xi32> -> i32
+func @extract_element_vectors(%vec1 : vector<1xi1>, %vec5 : vector<5xi32>) {
+    // CHECK-NEXT: %{{.*}} = llhd.extract_element %[[VEC1]], 0 : vector<1xi1> -> i1
+    %0 = llhd.extract_element %vec1, 0 : vector<1xi1> -> i1
+    // CHECK-NEXT: %{{.*}} = llhd.extract_element %[[VEC5]], 4 : vector<5xi32> -> i32
+    %1 = llhd.extract_element %vec5, 4 : vector<5xi32> -> i32
 
     return
 }
 
-// CHECK-LABEL: @extf_tuples
+// CHECK-LABEL: @extract_element_tuples
 // CHECK-SAME: %[[TUP:.*]]: tuple<i1, i2, i3>
-func @extf_tuples(%tup : tuple<i1, i2, i3>) {
-    // CHECK-NEXT: %{{.*}} = llhd.extf %[[TUP]], 0 : tuple<i1, i2, i3> -> i1
-    %0 = llhd.extf %tup, 0 : tuple<i1, i2, i3> -> i1
-    // CHECK-NEXT: %{{.*}} = llhd.extf %[[TUP]], 2 : tuple<i1, i2, i3> -> i3
-    %1 = llhd.extf %tup, 2 : tuple<i1, i2, i3> -> i3
+func @extract_element_tuples(%tup : tuple<i1, i2, i3>) {
+    // CHECK-NEXT: %{{.*}} = llhd.extract_element %[[TUP]], 0 : tuple<i1, i2, i3> -> i1
+    %0 = llhd.extract_element %tup, 0 : tuple<i1, i2, i3> -> i1
+    // CHECK-NEXT: %{{.*}} = llhd.extract_element %[[TUP]], 2 : tuple<i1, i2, i3> -> i3
+    %1 = llhd.extract_element %tup, 2 : tuple<i1, i2, i3> -> i3
 
     return
 }
 
-// CHECK-LABEL: @extf_signals_of_vectors
+// CHECK-LABEL: @extract_element_signals_of_vectors
 // CHECK-SAME: %[[VEC1:.*]]: !llhd.sig<vector<1xi1>>
 // CHECK-SAME: %[[VEC5:.*]]: !llhd.sig<vector<5xi32>>
-func @extf_signals_of_vectors(%vec1 : !llhd.sig<vector<1xi1>>, %vec5 : !llhd.sig<vector<5xi32>>) {
-    // CHECK-NEXT: %{{.*}} = llhd.extf %[[VEC1]], 0 : !llhd.sig<vector<1xi1>> -> !llhd.sig<i1>
-    %0 = llhd.extf %vec1, 0 : !llhd.sig<vector<1xi1>> -> !llhd.sig<i1>
-    // CHECK-NEXT: %{{.*}} = llhd.extf %[[VEC5]], 4 : !llhd.sig<vector<5xi32>> -> !llhd.sig<i32>
-    %1 = llhd.extf %vec5, 4 : !llhd.sig<vector<5xi32>> -> !llhd.sig<i32>
+func @extract_element_signals_of_vectors(%vec1 : !llhd.sig<vector<1xi1>>, %vec5 : !llhd.sig<vector<5xi32>>) {
+    // CHECK-NEXT: %{{.*}} = llhd.extract_element %[[VEC1]], 0 : !llhd.sig<vector<1xi1>> -> !llhd.sig<i1>
+    %0 = llhd.extract_element %vec1, 0 : !llhd.sig<vector<1xi1>> -> !llhd.sig<i1>
+    // CHECK-NEXT: %{{.*}} = llhd.extract_element %[[VEC5]], 4 : !llhd.sig<vector<5xi32>> -> !llhd.sig<i32>
+    %1 = llhd.extract_element %vec5, 4 : !llhd.sig<vector<5xi32>> -> !llhd.sig<i32>
 
     return
 }
 
-// CHECK-LABEL: @extf_signals_of_tuples
+// CHECK-LABEL: @extract_element_signals_of_tuples
 // CHECK-SAME: %[[TUP:.*]]: !llhd.sig<tuple<i1, i2, i3>>
-func @extf_signals_of_tuples(%tup : !llhd.sig<tuple<i1, i2, i3>>) {
-    // CHECK-NEXT: %{{.*}} = llhd.extf %[[TUP]], 0 : !llhd.sig<tuple<i1, i2, i3>> -> !llhd.sig<i1>
-    %0 = llhd.extf %tup, 0 : !llhd.sig<tuple<i1, i2, i3>> -> !llhd.sig<i1>
-    // CHECK-NEXT: %{{.*}} = llhd.extf %[[TUP]], 2 : !llhd.sig<tuple<i1, i2, i3>> -> !llhd.sig<i3>
-    %1 = llhd.extf %tup, 2 : !llhd.sig<tuple<i1, i2, i3>> -> !llhd.sig<i3>
+func @extract_element_signals_of_tuples(%tup : !llhd.sig<tuple<i1, i2, i3>>) {
+    // CHECK-NEXT: %{{.*}} = llhd.extract_element %[[TUP]], 0 : !llhd.sig<tuple<i1, i2, i3>> -> !llhd.sig<i1>
+    %0 = llhd.extract_element %tup, 0 : !llhd.sig<tuple<i1, i2, i3>> -> !llhd.sig<i1>
+    // CHECK-NEXT: %{{.*}} = llhd.extract_element %[[TUP]], 2 : !llhd.sig<tuple<i1, i2, i3>> -> !llhd.sig<i3>
+    %1 = llhd.extract_element %tup, 2 : !llhd.sig<tuple<i1, i2, i3>> -> !llhd.sig<i3>
 
     return
 }
 
-// CHECK-LABEL: @dextf_vectors
+// CHECK-LABEL: @dyn_extract_element_vectors
 // CHECK-SAME: %[[INDEX:.*]]: i32
 // CHECK-SAME: %[[VEC1:.*]]: vector<1xi1>
 // CHECK-SAME: %[[VEC5:.*]]: vector<5xi32>
-func @dextf_vectors(%index : i32, %vec1 : vector<1xi1>, %vec5 : vector<5xi32>) {
-    // CHECK-NEXT: %{{.*}} = llhd.dextf %[[VEC1]], %[[INDEX]] : (vector<1xi1>, i32) -> i1
-    %0 = llhd.dextf %vec1, %index : (vector<1xi1>, i32) -> i1
-    // CHECK-NEXT: %{{.*}} = llhd.dextf %[[VEC5]], %[[INDEX]] : (vector<5xi32>, i32) -> i32
-    %1 = llhd.dextf %vec5, %index : (vector<5xi32>, i32) -> i32
+func @dyn_extract_element_vectors(%index : i32, %vec1 : vector<1xi1>, %vec5 : vector<5xi32>) {
+    // CHECK-NEXT: %{{.*}} = llhd.dyn_extract_element %[[VEC1]], %[[INDEX]] : (vector<1xi1>, i32) -> i1
+    %0 = llhd.dyn_extract_element %vec1, %index : (vector<1xi1>, i32) -> i1
+    // CHECK-NEXT: %{{.*}} = llhd.dyn_extract_element %[[VEC5]], %[[INDEX]] : (vector<5xi32>, i32) -> i32
+    %1 = llhd.dyn_extract_element %vec5, %index : (vector<5xi32>, i32) -> i32
 
     return
 }
 
-// CHECK-LABEL: @dextf_signals_of_vectors
+// CHECK-LABEL: @dyn_extract_element_signals_of_vectors
 // CHECK-SAME: %[[INDEX:.*]]: i32
 // CHECK-SAME: %[[VEC1:.*]]: !llhd.sig<vector<1xi1>>
 // CHECK-SAME: %[[VEC5:.*]]: !llhd.sig<vector<5xi32>>
-func @dextf_signals_of_vectors(%index : i32, %vec1 : !llhd.sig<vector<1xi1>>, %vec5 : !llhd.sig<vector<5xi32>>) {
-    // CHECK-NEXT: %{{.*}} = llhd.dextf %[[VEC1]], %[[INDEX]] : (!llhd.sig<vector<1xi1>>, i32) -> !llhd.sig<i1>
-    %0 = llhd.dextf %vec1, %index : (!llhd.sig<vector<1xi1>>, i32) -> !llhd.sig<i1>
-    // CHECK-NEXT: %{{.*}} = llhd.dextf %[[VEC5]], %[[INDEX]] : (!llhd.sig<vector<5xi32>>, i32) -> !llhd.sig<i32>
-    %1 = llhd.dextf %vec5, %index : (!llhd.sig<vector<5xi32>>, i32) -> !llhd.sig<i32>
+func @dyn_extract_element_signals_of_vectors(%index : i32, %vec1 : !llhd.sig<vector<1xi1>>, %vec5 : !llhd.sig<vector<5xi32>>) {
+    // CHECK-NEXT: %{{.*}} = llhd.dyn_extract_element %[[VEC1]], %[[INDEX]] : (!llhd.sig<vector<1xi1>>, i32) -> !llhd.sig<i1>
+    %0 = llhd.dyn_extract_element %vec1, %index : (!llhd.sig<vector<1xi1>>, i32) -> !llhd.sig<i1>
+    // CHECK-NEXT: %{{.*}} = llhd.dyn_extract_element %[[VEC5]], %[[INDEX]] : (!llhd.sig<vector<5xi32>>, i32) -> !llhd.sig<i32>
+    %1 = llhd.dyn_extract_element %vec5, %index : (!llhd.sig<vector<5xi32>>, i32) -> !llhd.sig<i32>
 
     return
 }
@@ -292,81 +292,81 @@ func @dexts_illegal_vec_element_conversion(%c : vector<1xi1>, %i : i1) {
 
 // -----
 
-func @extf_vector_index_out_of_bounds(%vec : vector<3xi1>) {
-    // expected-error @+1 {{'index' has to be smaller than the 'target' size}}
-    %0 = llhd.extf %vec, 3 : vector<3xi1> -> i1
+func @extract_element_vector_index_out_of_bounds(%vec : vector<3xi1>) {
+    // expected-error @+1 {{'index' has to be smaller than the width of the 'target' type}}
+    %0 = llhd.extract_element %vec, 3 : vector<3xi1> -> i1
 
     return
 }
 
 // -----
 
-func @extf_tuple_index_out_of_bounds(%tup : tuple<i1, i2, i3>) {
-    // expected-error @+1 {{'index' has to be smaller than the 'target' size}}
-    %0 = llhd.extf %tup, 3 : tuple<i1, i2, i3> -> i3
+func @extract_element_tuple_index_out_of_bounds(%tup : tuple<i1, i2, i3>) {
+    // expected-error @+1 {{'index' has to be smaller than the width of the 'target' type}}
+    %0 = llhd.extract_element %tup, 3 : tuple<i1, i2, i3> -> i3
 
     return
 }
 
 // -----
 
-func @extf_vector_type_mismatch(%vec : vector<3xi1>) {
-    // expected-error @+1 {{'result' type has to match type at 'index' of 'target', in case 'target' is a singal, consider the underlying types of the 'target' and 'result' signals}}
-    %0 = llhd.extf %vec, 0 : vector<3xi1> -> i2
+func @extract_element_vector_type_mismatch(%vec : vector<3xi1>) {
+    // expected-error @+1 {{'result' type must match the type of 'target' at position 'index', or in case 'target' is a signal, it must be a signal of the underlying type of 'target' at position 'index'}}
+    %0 = llhd.extract_element %vec, 0 : vector<3xi1> -> i2
 
     return
 }
 
 // -----
 
-func @extf_tuple_type_mismatch(%tup : tuple<i1, i2, i3>) {
-    // expected-error @+1 {{'result' type has to match type at 'index' of 'target', in case 'target' is a singal, consider the underlying types of the 'target' and 'result' signals}}
-    %0 = llhd.extf %tup, 0 : tuple<i1, i2, i3> -> i2
+func @extract_element_tuple_type_mismatch(%tup : tuple<i1, i2, i3>) {
+    // expected-error @+1 {{'result' type must match the type of 'target' at position 'index', or in case 'target' is a signal, it must be a signal of the underlying type of 'target' at position 'index'}}
+    %0 = llhd.extract_element %tup, 0 : tuple<i1, i2, i3> -> i2
 
     return
 }
 
 // -----
 
-func @extf_signal_type_mismatch(%sig : !llhd.sig<tuple<i1, i2, i3>>) {
-    // expected-error @+1 {{'result' type has to match type at 'index' of 'target', in case 'target' is a singal, consider the underlying types of the 'target' and 'result' signals}}
-    %0 = llhd.extf %sig, 0 : !llhd.sig<tuple<i1, i2, i3>> -> !llhd.sig<i2>
+func @extract_element_signal_type_mismatch(%sig : !llhd.sig<tuple<i1, i2, i3>>) {
+    // expected-error @+1 {{'result' type must match the type of 'target' at position 'index', or in case 'target' is a signal, it must be a signal of the underlying type of 'target' at position 'index'}}
+    %0 = llhd.extract_element %sig, 0 : !llhd.sig<tuple<i1, i2, i3>> -> !llhd.sig<i2>
 
     return
 }
 
 // -----
 
-func @extf_illegal_signal_alias(%sig : !llhd.sig<tuple<i1, i2, i3>>) {
-    // expected-error @+1 {{'result' type has to match type at 'index' of 'target', in case 'target' is a singal, consider the underlying types of the 'target' and 'result' signals}}
-    %0 = llhd.extf %sig, 0 : !llhd.sig<tuple<i1, i2, i3>> -> i1
+func @extract_element_illegal_signal_alias(%sig : !llhd.sig<tuple<i1, i2, i3>>) {
+    // expected-error @+1 {{'result' type must match the type of 'target' at position 'index', or in case 'target' is a signal, it must be a signal of the underlying type of 'target' at position 'index'}}
+    %0 = llhd.extract_element %sig, 0 : !llhd.sig<tuple<i1, i2, i3>> -> i1
 
     return
 }
 
 // -----
 
-func @dextf_vector_type_mismatch(%index : i2, %vec : vector<3xi1>) {
+func @dyn_extract_element_vector_type_mismatch(%index : i2, %vec : vector<3xi1>) {
     // expected-error @+1 {{'result' must be the element type of the 'target' vector, in case 'target' is a signal of a vector, 'result' also is a signal of the vector element type}}
-    %0 = llhd.dextf %vec, %index : (vector<3xi1>, i2) -> i2
+    %0 = llhd.dyn_extract_element %vec, %index : (vector<3xi1>, i2) -> i2
 
     return
 }
 
 // -----
 
-func @dextf_signal_type_mismatch(%index : i2, %sig : !llhd.sig<vector<3xi1>>) {
+func @dyn_extract_element_signal_type_mismatch(%index : i2, %sig : !llhd.sig<vector<3xi1>>) {
     // expected-error @+1 {{'result' must be the element type of the 'target' vector, in case 'target' is a signal of a vector, 'result' also is a signal of the vector element type}}
-    %0 = llhd.dextf %sig, %index : (!llhd.sig<vector<3xi1>>, i2) -> !llhd.sig<i2>
+    %0 = llhd.dyn_extract_element %sig, %index : (!llhd.sig<vector<3xi1>>, i2) -> !llhd.sig<i2>
 
     return
 }
 
 // -----
 
-func @dextf_illegal_signal_alias(%index : i2, %sig : !llhd.sig<vector<3xi1>>) {
+func @dyn_extract_element_illegal_signal_alias(%index : i2, %sig : !llhd.sig<vector<3xi1>>) {
     // expected-error @+1 {{'result' must be the element type of the 'target' vector, in case 'target' is a signal of a vector, 'result' also is a signal of the vector element type}}
-    %0 = llhd.dextf %sig, %index : (!llhd.sig<vector<3xi1>>, i2) -> i1
+    %0 = llhd.dyn_extract_element %sig, %index : (!llhd.sig<vector<3xi1>>, i2) -> i1
 
     return
 }

--- a/test/Dialect/LLHD/IR/extract.mlir
+++ b/test/Dialect/LLHD/IR/extract.mlir
@@ -4,36 +4,36 @@
 // CHECK-SAME: %[[CI1:.*]]: i1
 // CHECK-SAME: %[[CI32:.*]]: i32
 func @exts_integers(%cI1 : i1, %cI32 : i32) {
-    // CHECK-NEXT: %{{.*}} = llhd.exts %[[CI1]], 0 : i1 -> i1
-    %0 = llhd.exts %cI1, 0 : i1 -> i1
-    // CHECK-NEXT: %{{.*}} = llhd.exts %[[CI32]], 0 : i32 -> i5
-    %1 = llhd.exts %cI32, 0 : i32 -> i5
+  // CHECK-NEXT: %{{.*}} = llhd.exts %[[CI1]], 0 : i1 -> i1
+  %0 = llhd.exts %cI1, 0 : i1 -> i1
+  // CHECK-NEXT: %{{.*}} = llhd.exts %[[CI32]], 0 : i32 -> i5
+  %1 = llhd.exts %cI32, 0 : i32 -> i5
 
-    return
+  return
 }
 
 // CHECK-LABEL: @exts_signals
 // CHECK-SAME: %[[SI1:.*]]: !llhd.sig<i1>
 // CHECK-SAME: %[[SI32:.*]]: !llhd.sig<i32>
 func @exts_signals (%sI1 : !llhd.sig<i1>, %sI32 : !llhd.sig<i32>) -> () {
-    // CHECK-NEXT: %{{.*}} = llhd.exts %[[SI1]], 0 : !llhd.sig<i1> -> !llhd.sig<i1>
-    %0 = llhd.exts %sI1, 0 : !llhd.sig<i1> -> !llhd.sig<i1>
-    // CHECK-NEXT: %{{.*}} = llhd.exts %[[SI32]], 0 : !llhd.sig<i32> -> !llhd.sig<i5>
-    %1 = llhd.exts %sI32, 0 : !llhd.sig<i32> -> !llhd.sig<i5>
+  // CHECK-NEXT: %{{.*}} = llhd.exts %[[SI1]], 0 : !llhd.sig<i1> -> !llhd.sig<i1>
+  %0 = llhd.exts %sI1, 0 : !llhd.sig<i1> -> !llhd.sig<i1>
+  // CHECK-NEXT: %{{.*}} = llhd.exts %[[SI32]], 0 : !llhd.sig<i32> -> !llhd.sig<i5>
+  %1 = llhd.exts %sI32, 0 : !llhd.sig<i32> -> !llhd.sig<i5>
 
-    return
+  return
 }
 
 // CHECK-LABEL: @exts_vector_signals
 // CHECK-SAME: %[[VEC5:.*]]: !llhd.sig<vector<5xi1>>
 // CHECK-SAME: %[[VEC1:.*]]: !llhd.sig<vector<1xi32>>
 func @exts_vector_signals (%vec5 : !llhd.sig<vector<5xi1>>, %vec1 : !llhd.sig<vector<1xi32>>) -> () {
-    // CHECK-NEXT: %{{.*}} = llhd.exts %[[VEC5]], 2 : !llhd.sig<vector<5xi1>> -> !llhd.sig<vector<3xi1>>
-    %0 = llhd.exts %vec5, 2 : !llhd.sig<vector<5xi1>> -> !llhd.sig<vector<3xi1>>
-    // CHECK-NEXT: %{{.*}} = llhd.exts %[[VEC1]], 0 : !llhd.sig<vector<1xi32>> -> !llhd.sig<vector<1xi32>>
-    %1 = llhd.exts %vec1, 0 : !llhd.sig<vector<1xi32>> -> !llhd.sig<vector<1xi32>>
+  // CHECK-NEXT: %{{.*}} = llhd.exts %[[VEC5]], 2 : !llhd.sig<vector<5xi1>> -> !llhd.sig<vector<3xi1>>
+  %0 = llhd.exts %vec5, 2 : !llhd.sig<vector<5xi1>> -> !llhd.sig<vector<3xi1>>
+  // CHECK-NEXT: %{{.*}} = llhd.exts %[[VEC1]], 0 : !llhd.sig<vector<1xi32>> -> !llhd.sig<vector<1xi32>>
+  %1 = llhd.exts %vec1, 0 : !llhd.sig<vector<1xi32>> -> !llhd.sig<vector<1xi32>>
 
-    return
+  return
 }
 
 // CHECK-LABEL: @dexts_integers
@@ -42,12 +42,12 @@ func @exts_vector_signals (%vec5 : !llhd.sig<vector<5xi1>>, %vec1 : !llhd.sig<ve
 // CHECK-SAME: %[[IND0:.*]]: i5,
 // CHECK-SAME: %[[IND1:.*]]: i10
 func @dexts_integers(%cI1 : i1, %cI32 : i32, %i0 : i5, %i1 : i10) {
-    // CHECK-NEXT: %{{.*}} = llhd.dexts %[[CI1]], %[[IND0]] : (i1, i5) -> i1
-    %0 = llhd.dexts %cI1, %i0 : (i1, i5) -> i1
-    // CHECK-NEXT: %{{.*}} = llhd.dexts %[[CI32]], %[[IND1]] : (i32, i10) -> i15
-    %1 = llhd.dexts %cI32, %i1 : (i32, i10) -> i15
+  // CHECK-NEXT: %{{.*}} = llhd.dexts %[[CI1]], %[[IND0]] : (i1, i5) -> i1
+  %0 = llhd.dexts %cI1, %i0 : (i1, i5) -> i1
+  // CHECK-NEXT: %{{.*}} = llhd.dexts %[[CI32]], %[[IND1]] : (i32, i10) -> i15
+  %1 = llhd.dexts %cI32, %i1 : (i32, i10) -> i15
 
-    return
+  return
 }
 
 // CHECK-LABEL: @dexts_signals
@@ -56,12 +56,12 @@ func @dexts_integers(%cI1 : i1, %cI32 : i32, %i0 : i5, %i1 : i10) {
 // CHECK-SAME: %[[IND0:.*]]: i5,
 // CHECK-SAME: %[[IND1:.*]]: i10
 func @dexts_signals (%sI1 : !llhd.sig<i1>, %sI32 : !llhd.sig<i32>, %i0 : i5, %i1 : i10) {
-    // CHECK-NEXT: %{{.*}} = llhd.dexts %[[SI1]], %[[IND0]] : (!llhd.sig<i1>, i5) -> !llhd.sig<i1>
-    %0 = llhd.dexts %sI1, %i0 : (!llhd.sig<i1>, i5) -> !llhd.sig<i1>
-    // CHECK-NEXT: %{{.*}} = llhd.dexts %[[SI32]], %[[IND1]] : (!llhd.sig<i32>, i10) -> !llhd.sig<i5>
-    %1 = llhd.dexts %sI32, %i1 : (!llhd.sig<i32>, i10) -> !llhd.sig<i5>
+  // CHECK-NEXT: %{{.*}} = llhd.dexts %[[SI1]], %[[IND0]] : (!llhd.sig<i1>, i5) -> !llhd.sig<i1>
+  %0 = llhd.dexts %sI1, %i0 : (!llhd.sig<i1>, i5) -> !llhd.sig<i1>
+  // CHECK-NEXT: %{{.*}} = llhd.dexts %[[SI32]], %[[IND1]] : (!llhd.sig<i32>, i10) -> !llhd.sig<i5>
+  %1 = llhd.dexts %sI32, %i1 : (!llhd.sig<i32>, i10) -> !llhd.sig<i5>
 
-    return
+  return
 }
 
 // CHECK-LABEL: @dexts_vector_signals
@@ -70,12 +70,12 @@ func @dexts_signals (%sI1 : !llhd.sig<i1>, %sI32 : !llhd.sig<i32>, %i0 : i5, %i1
 // CHECK-SAME: %[[IND0:.*]]: i5,
 // CHECK-SAME: %[[IND1:.*]]: i10
 func @dexts_vector_signals (%sI1 : !llhd.sig<vector<5xi1>>, %sI32 : !llhd.sig<vector<1xi32>>, %i0 : i5, %i1 : i10) {
-    // CHECK-NEXT: %{{.*}} = llhd.dexts %[[SI1]], %[[IND0]] : (!llhd.sig<vector<5xi1>>, i5) -> !llhd.sig<vector<2xi1>>
-    %0 = llhd.dexts %sI1, %i0 : (!llhd.sig<vector<5xi1>>, i5) -> !llhd.sig<vector<2xi1>>
-    // CHECK-NEXT: %{{.*}} = llhd.dexts %[[SI32]], %[[IND1]] : (!llhd.sig<vector<1xi32>>, i10) -> !llhd.sig<vector<1xi32>>
-    %1 = llhd.dexts %sI32, %i1 : (!llhd.sig<vector<1xi32>>, i10) -> !llhd.sig<vector<1xi32>>
+  // CHECK-NEXT: %{{.*}} = llhd.dexts %[[SI1]], %[[IND0]] : (!llhd.sig<vector<5xi1>>, i5) -> !llhd.sig<vector<2xi1>>
+  %0 = llhd.dexts %sI1, %i0 : (!llhd.sig<vector<5xi1>>, i5) -> !llhd.sig<vector<2xi1>>
+  // CHECK-NEXT: %{{.*}} = llhd.dexts %[[SI32]], %[[IND1]] : (!llhd.sig<vector<1xi32>>, i10) -> !llhd.sig<vector<1xi32>>
+  %1 = llhd.dexts %sI32, %i1 : (!llhd.sig<vector<1xi32>>, i10) -> !llhd.sig<vector<1xi32>>
 
-    return
+  return
 }
 
 // CHECK-LABEL: @dexts_vec
@@ -84,58 +84,58 @@ func @dexts_vector_signals (%sI1 : !llhd.sig<vector<5xi1>>, %sI32 : !llhd.sig<ve
 // CHECK-SAME: %[[IND0:.*]]: i5,
 // CHECK-SAME: %[[IND1:.*]]: i10
 func @dexts_vec(%v1 : vector<1xi1>, %v10 : vector<10xi1>, %i0 : i5, %i1 : i10) {
-    // CHECK-NEXT: %{{.*}} = llhd.dexts %[[V1]], %[[IND0]] : (vector<1xi1>, i5) -> vector<1xi1>
-    %0 = llhd.dexts %v1, %i0 : (vector<1xi1>, i5) -> vector<1xi1>
-    // CHECK-NEXT: %{{.*}} = llhd.dexts %[[V10]], %[[IND1]] : (vector<10xi1>, i10) -> vector<5xi1>
-    %1 = llhd.dexts %v10, %i1 : (vector<10xi1>, i10) -> vector<5xi1>
+  // CHECK-NEXT: %{{.*}} = llhd.dexts %[[V1]], %[[IND0]] : (vector<1xi1>, i5) -> vector<1xi1>
+  %0 = llhd.dexts %v1, %i0 : (vector<1xi1>, i5) -> vector<1xi1>
+  // CHECK-NEXT: %{{.*}} = llhd.dexts %[[V10]], %[[IND1]] : (vector<10xi1>, i10) -> vector<5xi1>
+  %1 = llhd.dexts %v10, %i1 : (vector<10xi1>, i10) -> vector<5xi1>
 
-    return
+  return
 }
 
 // CHECK-LABEL: @extract_element_vectors
 // CHECK-SAME: %[[VEC1:.*]]: vector<1xi1>
 // CHECK-SAME: %[[VEC5:.*]]: vector<5xi32>
 func @extract_element_vectors(%vec1 : vector<1xi1>, %vec5 : vector<5xi32>) {
-    // CHECK-NEXT: %{{.*}} = llhd.extract_element %[[VEC1]], 0 : vector<1xi1> -> i1
-    %0 = llhd.extract_element %vec1, 0 : vector<1xi1> -> i1
-    // CHECK-NEXT: %{{.*}} = llhd.extract_element %[[VEC5]], 4 : vector<5xi32> -> i32
-    %1 = llhd.extract_element %vec5, 4 : vector<5xi32> -> i32
+  // CHECK-NEXT: %{{.*}} = llhd.extract_element %[[VEC1]], 0 : vector<1xi1> -> i1
+  %0 = llhd.extract_element %vec1, 0 : vector<1xi1> -> i1
+  // CHECK-NEXT: %{{.*}} = llhd.extract_element %[[VEC5]], 4 : vector<5xi32> -> i32
+  %1 = llhd.extract_element %vec5, 4 : vector<5xi32> -> i32
 
-    return
+  return
 }
 
 // CHECK-LABEL: @extract_element_tuples
 // CHECK-SAME: %[[TUP:.*]]: tuple<i1, i2, i3>
 func @extract_element_tuples(%tup : tuple<i1, i2, i3>) {
-    // CHECK-NEXT: %{{.*}} = llhd.extract_element %[[TUP]], 0 : tuple<i1, i2, i3> -> i1
-    %0 = llhd.extract_element %tup, 0 : tuple<i1, i2, i3> -> i1
-    // CHECK-NEXT: %{{.*}} = llhd.extract_element %[[TUP]], 2 : tuple<i1, i2, i3> -> i3
-    %1 = llhd.extract_element %tup, 2 : tuple<i1, i2, i3> -> i3
+  // CHECK-NEXT: %{{.*}} = llhd.extract_element %[[TUP]], 0 : tuple<i1, i2, i3> -> i1
+  %0 = llhd.extract_element %tup, 0 : tuple<i1, i2, i3> -> i1
+  // CHECK-NEXT: %{{.*}} = llhd.extract_element %[[TUP]], 2 : tuple<i1, i2, i3> -> i3
+  %1 = llhd.extract_element %tup, 2 : tuple<i1, i2, i3> -> i3
 
-    return
+  return
 }
 
 // CHECK-LABEL: @extract_element_signals_of_vectors
 // CHECK-SAME: %[[VEC1:.*]]: !llhd.sig<vector<1xi1>>
 // CHECK-SAME: %[[VEC5:.*]]: !llhd.sig<vector<5xi32>>
 func @extract_element_signals_of_vectors(%vec1 : !llhd.sig<vector<1xi1>>, %vec5 : !llhd.sig<vector<5xi32>>) {
-    // CHECK-NEXT: %{{.*}} = llhd.extract_element %[[VEC1]], 0 : !llhd.sig<vector<1xi1>> -> !llhd.sig<i1>
-    %0 = llhd.extract_element %vec1, 0 : !llhd.sig<vector<1xi1>> -> !llhd.sig<i1>
-    // CHECK-NEXT: %{{.*}} = llhd.extract_element %[[VEC5]], 4 : !llhd.sig<vector<5xi32>> -> !llhd.sig<i32>
-    %1 = llhd.extract_element %vec5, 4 : !llhd.sig<vector<5xi32>> -> !llhd.sig<i32>
+  // CHECK-NEXT: %{{.*}} = llhd.extract_element %[[VEC1]], 0 : !llhd.sig<vector<1xi1>> -> !llhd.sig<i1>
+  %0 = llhd.extract_element %vec1, 0 : !llhd.sig<vector<1xi1>> -> !llhd.sig<i1>
+  // CHECK-NEXT: %{{.*}} = llhd.extract_element %[[VEC5]], 4 : !llhd.sig<vector<5xi32>> -> !llhd.sig<i32>
+  %1 = llhd.extract_element %vec5, 4 : !llhd.sig<vector<5xi32>> -> !llhd.sig<i32>
 
-    return
+  return
 }
 
 // CHECK-LABEL: @extract_element_signals_of_tuples
 // CHECK-SAME: %[[TUP:.*]]: !llhd.sig<tuple<i1, i2, i3>>
 func @extract_element_signals_of_tuples(%tup : !llhd.sig<tuple<i1, i2, i3>>) {
-    // CHECK-NEXT: %{{.*}} = llhd.extract_element %[[TUP]], 0 : !llhd.sig<tuple<i1, i2, i3>> -> !llhd.sig<i1>
-    %0 = llhd.extract_element %tup, 0 : !llhd.sig<tuple<i1, i2, i3>> -> !llhd.sig<i1>
-    // CHECK-NEXT: %{{.*}} = llhd.extract_element %[[TUP]], 2 : !llhd.sig<tuple<i1, i2, i3>> -> !llhd.sig<i3>
-    %1 = llhd.extract_element %tup, 2 : !llhd.sig<tuple<i1, i2, i3>> -> !llhd.sig<i3>
+  // CHECK-NEXT: %{{.*}} = llhd.extract_element %[[TUP]], 0 : !llhd.sig<tuple<i1, i2, i3>> -> !llhd.sig<i1>
+  %0 = llhd.extract_element %tup, 0 : !llhd.sig<tuple<i1, i2, i3>> -> !llhd.sig<i1>
+  // CHECK-NEXT: %{{.*}} = llhd.extract_element %[[TUP]], 2 : !llhd.sig<tuple<i1, i2, i3>> -> !llhd.sig<i3>
+  %1 = llhd.extract_element %tup, 2 : !llhd.sig<tuple<i1, i2, i3>> -> !llhd.sig<i3>
 
-    return
+  return
 }
 
 // CHECK-LABEL: @dyn_extract_element_vectors
@@ -143,12 +143,12 @@ func @extract_element_signals_of_tuples(%tup : !llhd.sig<tuple<i1, i2, i3>>) {
 // CHECK-SAME: %[[VEC1:.*]]: vector<1xi1>
 // CHECK-SAME: %[[VEC5:.*]]: vector<5xi32>
 func @dyn_extract_element_vectors(%index : i32, %vec1 : vector<1xi1>, %vec5 : vector<5xi32>) {
-    // CHECK-NEXT: %{{.*}} = llhd.dyn_extract_element %[[VEC1]], %[[INDEX]] : (vector<1xi1>, i32) -> i1
-    %0 = llhd.dyn_extract_element %vec1, %index : (vector<1xi1>, i32) -> i1
-    // CHECK-NEXT: %{{.*}} = llhd.dyn_extract_element %[[VEC5]], %[[INDEX]] : (vector<5xi32>, i32) -> i32
-    %1 = llhd.dyn_extract_element %vec5, %index : (vector<5xi32>, i32) -> i32
+  // CHECK-NEXT: %{{.*}} = llhd.dyn_extract_element %[[VEC1]], %[[INDEX]] : (vector<1xi1>, i32) -> i1
+  %0 = llhd.dyn_extract_element %vec1, %index : (vector<1xi1>, i32) -> i1
+  // CHECK-NEXT: %{{.*}} = llhd.dyn_extract_element %[[VEC5]], %[[INDEX]] : (vector<5xi32>, i32) -> i32
+  %1 = llhd.dyn_extract_element %vec5, %index : (vector<5xi32>, i32) -> i32
 
-    return
+  return
 }
 
 // CHECK-LABEL: @dyn_extract_element_signals_of_vectors
@@ -156,217 +156,217 @@ func @dyn_extract_element_vectors(%index : i32, %vec1 : vector<1xi1>, %vec5 : ve
 // CHECK-SAME: %[[VEC1:.*]]: !llhd.sig<vector<1xi1>>
 // CHECK-SAME: %[[VEC5:.*]]: !llhd.sig<vector<5xi32>>
 func @dyn_extract_element_signals_of_vectors(%index : i32, %vec1 : !llhd.sig<vector<1xi1>>, %vec5 : !llhd.sig<vector<5xi32>>) {
-    // CHECK-NEXT: %{{.*}} = llhd.dyn_extract_element %[[VEC1]], %[[INDEX]] : (!llhd.sig<vector<1xi1>>, i32) -> !llhd.sig<i1>
-    %0 = llhd.dyn_extract_element %vec1, %index : (!llhd.sig<vector<1xi1>>, i32) -> !llhd.sig<i1>
-    // CHECK-NEXT: %{{.*}} = llhd.dyn_extract_element %[[VEC5]], %[[INDEX]] : (!llhd.sig<vector<5xi32>>, i32) -> !llhd.sig<i32>
-    %1 = llhd.dyn_extract_element %vec5, %index : (!llhd.sig<vector<5xi32>>, i32) -> !llhd.sig<i32>
+  // CHECK-NEXT: %{{.*}} = llhd.dyn_extract_element %[[VEC1]], %[[INDEX]] : (!llhd.sig<vector<1xi1>>, i32) -> !llhd.sig<i1>
+  %0 = llhd.dyn_extract_element %vec1, %index : (!llhd.sig<vector<1xi1>>, i32) -> !llhd.sig<i1>
+  // CHECK-NEXT: %{{.*}} = llhd.dyn_extract_element %[[VEC5]], %[[INDEX]] : (!llhd.sig<vector<5xi32>>, i32) -> !llhd.sig<i32>
+  %1 = llhd.dyn_extract_element %vec5, %index : (!llhd.sig<vector<5xi32>>, i32) -> !llhd.sig<i32>
 
-    return
+  return
 }
 
 // -----
 
 func @illegal_vector_to_signal(%vec : vector<3xi32>) {
-    // expected-error @+1 {{failed to verify that 'target' and 'result' have to be both either signless integers, signals or vectors with the same element type}}
-    %0 = llhd.exts %vec, 0 : vector<3xi32> -> !llhd.sig<vector<3xi32>>
+  // expected-error @+1 {{failed to verify that 'target' and 'result' have to be both either signless integers, signals or vectors with the same element type}}
+  %0 = llhd.exts %vec, 0 : vector<3xi32> -> !llhd.sig<vector<3xi32>>
 
-    return
+  return
 }
 
 // -----
 
 func @illegal_signal_to_vector(%sig : !llhd.sig<vector<3xi32>>) {
-    // expected-error @+1 {{failed to verify that 'target' and 'result' have to be both either signless integers, signals or vectors with the same element type}}
-    %0 = llhd.exts %sig, 0 : !llhd.sig<vector<3xi32>> -> vector<3xi32>
+  // expected-error @+1 {{failed to verify that 'target' and 'result' have to be both either signless integers, signals or vectors with the same element type}}
+  %0 = llhd.exts %sig, 0 : !llhd.sig<vector<3xi32>> -> vector<3xi32>
 
-    return
+  return
 }
 
 // -----
 
 func @illegal_vector_element_type_mismatch(%sig : !llhd.sig<vector<3xi32>>) {
-    // expected-error @+1 {{failed to verify that 'target' and 'result' have to be both either signless integers, signals or vectors with the same element type}}
-    %0 = llhd.exts %sig, 0 : !llhd.sig<vector<3xi32>> -> !llhd.sig<vector<2xi1>>
+  // expected-error @+1 {{failed to verify that 'target' and 'result' have to be both either signless integers, signals or vectors with the same element type}}
+  %0 = llhd.exts %sig, 0 : !llhd.sig<vector<3xi32>> -> !llhd.sig<vector<2xi1>>
 
-    return
+  return
 }
 
 // -----
 
 func @illegal_result_vector_too_big(%sig : !llhd.sig<vector<3xi32>>) {
-    // expected-error @+1 {{'start' + size of the slice have to be smaller or equal to the 'target' size}}
-    %0 = llhd.exts %sig, 0 : !llhd.sig<vector<3xi32>> -> !llhd.sig<vector<4xi32>>
+  // expected-error @+1 {{'start' + size of the slice have to be smaller or equal to the 'target' size}}
+  %0 = llhd.exts %sig, 0 : !llhd.sig<vector<3xi32>> -> !llhd.sig<vector<4xi32>>
 
-    return
+  return
 }
 
 // -----
 
 func @illegal_int_to_sig(%c : i32) {
-    // expected-error @+1 {{failed to verify that 'target' and 'result' have to be both either signless integers, signals or vectors with the same element type}}
-    %0 = llhd.exts %c, 0 : i32 -> !llhd.sig<i10>
+  // expected-error @+1 {{failed to verify that 'target' and 'result' have to be both either signless integers, signals or vectors with the same element type}}
+  %0 = llhd.exts %c, 0 : i32 -> !llhd.sig<i10>
 
-    return
+  return
 }
 
 // -----
 
 func @illegal_sig_to_int(%s : !llhd.sig<i32>) {
-    // expected-error @+1 {{failed to verify that 'target' and 'result' have to be both either signless integers, signals or vectors with the same element type}}
-    %0 = llhd.exts %s, 0 : !llhd.sig<i32> -> i10
+  // expected-error @+1 {{failed to verify that 'target' and 'result' have to be both either signless integers, signals or vectors with the same element type}}
+  %0 = llhd.exts %s, 0 : !llhd.sig<i32> -> i10
 
-    return
+  return
 }
 
 // -----
 
 func @illegal_out_too_big(%c : i32) {
-    // expected-error @+1 {{failed to verify that 'start' + size of the slice have to be smaller or equal to the 'target' size}}
-    %0 = llhd.exts %c, 0 : i32 -> i40
+  // expected-error @+1 {{failed to verify that 'start' + size of the slice have to be smaller or equal to the 'target' size}}
+  %0 = llhd.exts %c, 0 : i32 -> i40
 
-    return
+  return
 }
 
 // -----
 
 func @illegal_vector_to_signal(%vec : vector<3xi32>, %index : i32) {
-    // expected-error @+1 {{'target' and 'result' types have to match apart from their width}}
-    %0 = llhd.dexts %vec, %index : (vector<3xi32>, i32) -> !llhd.sig<vector<3xi32>>
+  // expected-error @+1 {{'target' and 'result' types have to match apart from their width}}
+  %0 = llhd.dexts %vec, %index : (vector<3xi32>, i32) -> !llhd.sig<vector<3xi32>>
 
-    return
+  return
 }
 
 // -----
 
 func @illegal_signal_to_vector(%sig : !llhd.sig<vector<3xi32>>, %index: i32) {
-    // expected-error @+1 {{'target' and 'result' types have to match apart from their width}}
-    %0 = llhd.dexts %sig, %index : (!llhd.sig<vector<3xi32>>, i32) -> vector<3xi32>
+  // expected-error @+1 {{'target' and 'result' types have to match apart from their width}}
+  %0 = llhd.dexts %sig, %index : (!llhd.sig<vector<3xi32>>, i32) -> vector<3xi32>
 
-    return
+  return
 }
 
 // -----
 
 func @illegal_vector_element_type_mismatch(%sig : !llhd.sig<vector<3xi32>>, %index : i32) {
-    // expected-error @+1 {{'target' and 'result' types have to match apart from their width}}
-    %0 = llhd.dexts %sig, %index : (!llhd.sig<vector<3xi32>>, i32) -> !llhd.sig<vector<2xi1>>
+  // expected-error @+1 {{'target' and 'result' types have to match apart from their width}}
+  %0 = llhd.dexts %sig, %index : (!llhd.sig<vector<3xi32>>, i32) -> !llhd.sig<vector<2xi1>>
 
-    return
+  return
 }
 
 // -----
 
 func @illegal_result_vector_too_big(%sig : !llhd.sig<vector<3xi32>>, %index : i32) {
-    // expected-error @+1 {{the result width cannot be larger than the target operand width}}
-    %0 = llhd.dexts %sig, %index : (!llhd.sig<vector<3xi32>>, i32) -> !llhd.sig<vector<4xi32>>
+  // expected-error @+1 {{the result width cannot be larger than the target operand width}}
+  %0 = llhd.dexts %sig, %index : (!llhd.sig<vector<3xi32>>, i32) -> !llhd.sig<vector<4xi32>>
 
-    return
+  return
 }
 
 // -----
 
 func @dexts_illegal_conversion(%s : !llhd.sig<i32>, %i : i1) {
-    // expected-error @+1 {{'llhd.dexts' op failed to verify that 'target' and 'result' types have to match apart from their width}}
-    %0 = llhd.dexts %s, %i : (!llhd.sig<i32>, i1) -> i10
+  // expected-error @+1 {{'llhd.dexts' op failed to verify that 'target' and 'result' types have to match apart from their width}}
+  %0 = llhd.dexts %s, %i : (!llhd.sig<i32>, i1) -> i10
 
-    return
+  return
 }
 
 // -----
 
 func @dexts_illegal_out_too_wide(%c : i32, %i : i1) {
-    // expected-error @+1 {{'llhd.dexts' op failed to verify that the result width cannot be larger than the target operand width}}
-    %0 = llhd.dexts %c, %i : (i32, i1) -> i40
+  // expected-error @+1 {{'llhd.dexts' op failed to verify that the result width cannot be larger than the target operand width}}
+  %0 = llhd.dexts %c, %i : (i32, i1) -> i40
 
-    return
+  return
 }
 
 // -----
 
 func @dexts_illegal_vec_element_conversion(%c : vector<1xi1>, %i : i1) {
-    // expected-error @+1 {{'llhd.dexts' op failed to verify that 'target' and 'result' types have to match apart from their width}}
-    %0 = llhd.dexts %c, %i : (vector<1xi1>, i1) -> vector<1xi10>
+  // expected-error @+1 {{'llhd.dexts' op failed to verify that 'target' and 'result' types have to match apart from their width}}
+  %0 = llhd.dexts %c, %i : (vector<1xi1>, i1) -> vector<1xi10>
 
-    return
+  return
 }
 
 // -----
 
 func @extract_element_vector_index_out_of_bounds(%vec : vector<3xi1>) {
-    // expected-error @+1 {{'index' has to be smaller than the width of the 'target' type}}
-    %0 = llhd.extract_element %vec, 3 : vector<3xi1> -> i1
+  // expected-error @+1 {{'index' has to be smaller than the width of the 'target' type}}
+  %0 = llhd.extract_element %vec, 3 : vector<3xi1> -> i1
 
-    return
+  return
 }
 
 // -----
 
 func @extract_element_tuple_index_out_of_bounds(%tup : tuple<i1, i2, i3>) {
-    // expected-error @+1 {{'index' has to be smaller than the width of the 'target' type}}
-    %0 = llhd.extract_element %tup, 3 : tuple<i1, i2, i3> -> i3
+  // expected-error @+1 {{'index' has to be smaller than the width of the 'target' type}}
+  %0 = llhd.extract_element %tup, 3 : tuple<i1, i2, i3> -> i3
 
-    return
+  return
 }
 
 // -----
 
 func @extract_element_vector_type_mismatch(%vec : vector<3xi1>) {
-    // expected-error @+1 {{'result' type must match the type of 'target' at position 'index', or in case 'target' is a signal, it must be a signal of the underlying type of 'target' at position 'index'}}
-    %0 = llhd.extract_element %vec, 0 : vector<3xi1> -> i2
+  // expected-error @+1 {{'result' type must match the type of 'target' at position 'index', or in case 'target' is a signal, it must be a signal of the underlying type of 'target' at position 'index'}}
+  %0 = llhd.extract_element %vec, 0 : vector<3xi1> -> i2
 
-    return
+  return
 }
 
 // -----
 
 func @extract_element_tuple_type_mismatch(%tup : tuple<i1, i2, i3>) {
-    // expected-error @+1 {{'result' type must match the type of 'target' at position 'index', or in case 'target' is a signal, it must be a signal of the underlying type of 'target' at position 'index'}}
-    %0 = llhd.extract_element %tup, 0 : tuple<i1, i2, i3> -> i2
+  // expected-error @+1 {{'result' type must match the type of 'target' at position 'index', or in case 'target' is a signal, it must be a signal of the underlying type of 'target' at position 'index'}}
+  %0 = llhd.extract_element %tup, 0 : tuple<i1, i2, i3> -> i2
 
-    return
+  return
 }
 
 // -----
 
 func @extract_element_signal_type_mismatch(%sig : !llhd.sig<tuple<i1, i2, i3>>) {
-    // expected-error @+1 {{'result' type must match the type of 'target' at position 'index', or in case 'target' is a signal, it must be a signal of the underlying type of 'target' at position 'index'}}
-    %0 = llhd.extract_element %sig, 0 : !llhd.sig<tuple<i1, i2, i3>> -> !llhd.sig<i2>
+  // expected-error @+1 {{'result' type must match the type of 'target' at position 'index', or in case 'target' is a signal, it must be a signal of the underlying type of 'target' at position 'index'}}
+  %0 = llhd.extract_element %sig, 0 : !llhd.sig<tuple<i1, i2, i3>> -> !llhd.sig<i2>
 
-    return
+  return
 }
 
 // -----
 
 func @extract_element_illegal_signal_alias(%sig : !llhd.sig<tuple<i1, i2, i3>>) {
-    // expected-error @+1 {{'result' type must match the type of 'target' at position 'index', or in case 'target' is a signal, it must be a signal of the underlying type of 'target' at position 'index'}}
-    %0 = llhd.extract_element %sig, 0 : !llhd.sig<tuple<i1, i2, i3>> -> i1
+  // expected-error @+1 {{'result' type must match the type of 'target' at position 'index', or in case 'target' is a signal, it must be a signal of the underlying type of 'target' at position 'index'}}
+  %0 = llhd.extract_element %sig, 0 : !llhd.sig<tuple<i1, i2, i3>> -> i1
 
-    return
+  return
 }
 
 // -----
 
 func @dyn_extract_element_vector_type_mismatch(%index : i2, %vec : vector<3xi1>) {
-    // expected-error @+1 {{'result' must be the element type of the 'target' vector, in case 'target' is a signal of a vector, 'result' also is a signal of the vector element type}}
-    %0 = llhd.dyn_extract_element %vec, %index : (vector<3xi1>, i2) -> i2
+  // expected-error @+1 {{'result' must be the element type of the 'target' vector, in case 'target' is a signal of a vector, 'result' also is a signal of the vector element type}}
+  %0 = llhd.dyn_extract_element %vec, %index : (vector<3xi1>, i2) -> i2
 
-    return
+  return
 }
 
 // -----
 
 func @dyn_extract_element_signal_type_mismatch(%index : i2, %sig : !llhd.sig<vector<3xi1>>) {
-    // expected-error @+1 {{'result' must be the element type of the 'target' vector, in case 'target' is a signal of a vector, 'result' also is a signal of the vector element type}}
-    %0 = llhd.dyn_extract_element %sig, %index : (!llhd.sig<vector<3xi1>>, i2) -> !llhd.sig<i2>
+  // expected-error @+1 {{'result' must be the element type of the 'target' vector, in case 'target' is a signal of a vector, 'result' also is a signal of the vector element type}}
+  %0 = llhd.dyn_extract_element %sig, %index : (!llhd.sig<vector<3xi1>>, i2) -> !llhd.sig<i2>
 
-    return
+  return
 }
 
 // -----
 
 func @dyn_extract_element_illegal_signal_alias(%index : i2, %sig : !llhd.sig<vector<3xi1>>) {
-    // expected-error @+1 {{'result' must be the element type of the 'target' vector, in case 'target' is a signal of a vector, 'result' also is a signal of the vector element type}}
-    %0 = llhd.dyn_extract_element %sig, %index : (!llhd.sig<vector<3xi1>>, i2) -> i1
+  // expected-error @+1 {{'result' must be the element type of the 'target' vector, in case 'target' is a signal of a vector, 'result' also is a signal of the vector element type}}
+  %0 = llhd.dyn_extract_element %sig, %index : (!llhd.sig<vector<3xi1>>, i2) -> i1
 
-    return
+  return
 }


### PR DESCRIPTION
* Add operations to statically and dynamically extract an element from
a vector or tuple
* They can also operate on signals by returning an alias signal to the
specified element of the underlying type of the target signal, this
means they don't perform any kind of probing like the llhd.prb
instruction