### PR TITLE
[LLHD] Add equality operations

### DIFF
--- a/include/circt/Dialect/LLHD/IR/ArithmeticOps.td
+++ b/include/circt/Dialect/LLHD/IR/ArithmeticOps.td
@@ -59,3 +59,65 @@ def LLHD_SModOp : LLHD_ArithmeticOrBitwiseOp<"smod", []> {
 
   let hasFolder = 1;
 }
+
+def LLHD_EqOp : LLHD_Op<"eq", [
+    NoSideEffect,
+    Commutative,
+    AllTypesMatch<["lhs", "rhs"]>
+  ]> {
+  let summary = "Logical Equality";
+  let description = [{
+    This operation compares two values and returns 1 if they are the same and 0
+    otherwise. It is capable of comparing all types in the LLHD dialect. It
+    performs element-wise equality for vectors and tuples.
+
+    Examples:
+
+    ```mlir
+    %const1 = constant 1 : i32
+    %const2 = constant 2 : i32
+    %eq = llhd.eq %const1, %const2 : i32  // %eq = 0
+
+    %const3 = constant 0 : i1
+    %tup1 = llhd.tuple %const1, %const3 : tuple<i32, i1>
+    %tup2 = llhd.tuple %const2, %const3 : tuple<i32, i1>
+    %tupeq = llhd.eq %tup1, %tup2 : i32  // %tupeq = 0
+    ```
+  }];
+
+  let arguments = (ins AnyType:$lhs, AnyType:$rhs);
+  let results = (outs I1:$result);
+
+  let assemblyFormat = "operands attr-dict `:` type($lhs)";
+}
+
+def LLHD_NeqOp : LLHD_Op<"neq", [
+    NoSideEffect,
+    Commutative,
+    AllTypesMatch<["lhs", "rhs"]>
+  ]> {
+  let summary = "Logical Inequality";
+  let description = [{
+    This operation compares two values and returns 1 if they are not the same
+    and 0 if they are the same. It is capable of comparing all types in the LLHD
+    dialect. It performs element-wise equality for vectors and tuples.
+
+    Examples:
+
+    ```mlir
+    %const1 = constant 1 : i32
+    %const2 = constant 2 : i32
+    %neq = llhd.neq %const1, %const2 : i32  // %neq = 1
+
+    %const3 = constant 0 : i1
+    %tup1 = llhd.tuple %const1, %const3 : tuple<i32, i1>
+    %tup2 = llhd.tuple %const2, %const3 : tuple<i32, i1>
+    %tupneq = llhd.neq %tup1, %tup2 : i32  // %tupeq = 1
+    ```
+  }];
+
+  let arguments = (ins AnyType:$lhs, AnyType:$rhs);
+  let results = (outs I1:$result);
+
+  let assemblyFormat = "operands attr-dict `:` type($lhs)";
+}

--- a/include/circt/Dialect/LLHD/IR/ArithmeticOps.td
+++ b/include/circt/Dialect/LLHD/IR/ArithmeticOps.td
@@ -89,6 +89,8 @@ def LLHD_EqOp : LLHD_Op<"eq", [
   let results = (outs I1:$result);
 
   let assemblyFormat = "operands attr-dict `:` type($lhs)";
+
+  let hasFolder = 1;
 }
 
 def LLHD_NeqOp : LLHD_Op<"neq", [
@@ -120,4 +122,6 @@ def LLHD_NeqOp : LLHD_Op<"neq", [
   let results = (outs I1:$result);
 
   let assemblyFormat = "operands attr-dict `:` type($lhs)";
+
+  let hasFolder = 1;
 }

--- a/lib/Dialect/LLHD/IR/LLHDOps.cpp
+++ b/lib/Dialect/LLHD/IR/LLHDOps.cpp
@@ -237,13 +237,7 @@ OpFoldResult llhd::EqOp::fold(ArrayRef<Attribute> operands) {
   if (!operands[0] || !operands[1])
     return {};
 
-  if (auto lhs = operands[0].dyn_cast<IntegerAttr>()) {
-    if (auto rhs = operands[1].dyn_cast<IntegerAttr>()) {
-      return BoolAttr::get(lhs.getValue() == rhs.getValue(), getContext());
-    }
-  }
-
-  return {};
+  return BoolAttr::get(operands[0] == operands[1], getContext());
 }
 
 //===----------------------------------------------------------------------===//
@@ -262,13 +256,7 @@ OpFoldResult llhd::NeqOp::fold(ArrayRef<Attribute> operands) {
   if (!operands[0] || !operands[1])
     return {};
 
-  if (auto lhs = operands[0].dyn_cast<IntegerAttr>()) {
-    if (auto rhs = operands[1].dyn_cast<IntegerAttr>()) {
-      return BoolAttr::get(lhs.getValue() != rhs.getValue(), getContext());
-    }
-  }
-
-  return {};
+  return BoolAttr::get(operands[0] != operands[1], getContext());
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/LLHD/IR/LLHDOps.cpp
+++ b/lib/Dialect/LLHD/IR/LLHDOps.cpp
@@ -222,6 +222,56 @@ OpFoldResult llhd::SModOp::fold(ArrayRef<Attribute> operands) {
 }
 
 //===----------------------------------------------------------------------===//
+// EqOp
+//===----------------------------------------------------------------------===//
+
+OpFoldResult llhd::EqOp::fold(ArrayRef<Attribute> operands) {
+  /// llhd.eq(x, 1) -> x
+  if (matchPattern(rhs(), m_One()) && lhs().getType().isSignlessInteger(1))
+    return lhs();
+
+  /// llhs.eq(x,x) -> 1
+  if (lhs() == rhs())
+    return BoolAttr::get(true, getContext());
+
+  if (!operands[0] || !operands[1])
+    return {};
+
+  if (auto lhs = operands[0].dyn_cast<IntegerAttr>()) {
+    if (auto rhs = operands[1].dyn_cast<IntegerAttr>()) {
+      return BoolAttr::get(lhs.getValue() == rhs.getValue(), getContext());
+    }
+  }
+
+  return {};
+}
+
+//===----------------------------------------------------------------------===//
+// NeqOp
+//===----------------------------------------------------------------------===//
+
+OpFoldResult llhd::NeqOp::fold(ArrayRef<Attribute> operands) {
+  /// llhd.neq(x, 0) -> x
+  if (matchPattern(rhs(), m_Zero()) && lhs().getType().isSignlessInteger(1))
+    return lhs();
+
+  /// llhs.neq(x,x) -> 0
+  if (lhs() == rhs())
+    return BoolAttr::get(false, getContext());
+
+  if (!operands[0] || !operands[1])
+    return {};
+
+  if (auto lhs = operands[0].dyn_cast<IntegerAttr>()) {
+    if (auto rhs = operands[1].dyn_cast<IntegerAttr>()) {
+      return BoolAttr::get(lhs.getValue() != rhs.getValue(), getContext());
+    }
+  }
+
+  return {};
+}
+
+//===----------------------------------------------------------------------===//
 // NotOp
 //===----------------------------------------------------------------------===//
 

--- a/test/Dialect/LLHD/Canonicalization/arithmetic.mlir
+++ b/test/Dialect/LLHD/Canonicalization/arithmetic.mlir
@@ -2,29 +2,29 @@
 
 // CHECK-LABEL: @check_neg_folding
 func @check_neg_folding() -> (i16) {
-    // CHECK-NEXT: %[[NEG:.*]] = llhd.const -5 : i16
-    %a = llhd.const 5 : i16
-    %0 = llhd.neg %a : i16
+  // CHECK-NEXT: %[[NEG:.*]] = llhd.const -5 : i16
+  %a = llhd.const 5 : i16
+  %0 = llhd.neg %a : i16
 
-    // CHECK-NEXT: return %[[NEG]] : i16
-    return %0 : i16
+  // CHECK-NEXT: return %[[NEG]] : i16
+  return %0 : i16
 }
 
 // CHECK-LABEL: @check_smod_folding
 // CHECK-SAME: %[[VAL_0:.*]]: i64
 func @check_smod_folding(%a : i64) -> (i64, i64, i64) {
-    %c0 = llhd.const 0 : i64
-    %c1 = llhd.const 1 : i64
-    %c9 = llhd.const 9 : i64
-    %cn5 = llhd.const -5 : i64
-    // CHECK-NEXT: %[[VAL_1:.*]] = llhd.const 0 : i64
-    %0 = llhd.smod %a, %c1 : i64
-    %1 = llhd.smod %c0, %a : i64
-    // CHECK-NEXT: %[[VAL_2:.*]] = llhd.const -1 : i64
-    %2 = llhd.smod %c9, %cn5 : i64
+  %c0 = llhd.const 0 : i64
+  %c1 = llhd.const 1 : i64
+  %c9 = llhd.const 9 : i64
+  %cn5 = llhd.const -5 : i64
+  // CHECK-NEXT: %[[VAL_1:.*]] = llhd.const 0 : i64
+  %0 = llhd.smod %a, %c1 : i64
+  %1 = llhd.smod %c0, %a : i64
+  // CHECK-NEXT: %[[VAL_2:.*]] = llhd.const -1 : i64
+  %2 = llhd.smod %c9, %cn5 : i64
 
-    // CHECK-NEXT: return %[[VAL_1]], %[[VAL_1]], %[[VAL_2]] : i64, i64, i64
-    return %0, %1, %2 : i64, i64, i64
+  // CHECK-NEXT: return %[[VAL_1]], %[[VAL_1]], %[[VAL_2]] : i64, i64, i64
+  return %0, %1, %2 : i64, i64, i64
 }
 
 // CHECK-LABEL: @check_eq_folding
@@ -32,18 +32,18 @@ func @check_smod_folding(%a : i64) -> (i64, i64, i64) {
 // CHECK-SAME: %[[VAL_1:.*]]: i1,
 // CHECK-SAME: %[[VAL_2:.*]]: tuple<i1, i2, i3>
 func @check_eq_folding(%a : i64, %b : i1, %tup : tuple<i1, i2, i3>) -> (i1, i1, i1, i1) {
-    %c1 = llhd.const 1 : i1
-    %c3 = llhd.const 3 : i64
-    %c4 = llhd.const 4 : i64
-    %0 = llhd.eq %b, %c1 : i1
-    // CHECK-NEXT: %[[VAL_3:.*]] = llhd.const true : i1
-    %1 = llhd.eq %a, %a : i64
-    %2 = llhd.eq %tup, %tup : tuple<i1, i2, i3>
-    // CHECK-NEXT: %[[VAL_4:.*]] = llhd.const false : i1
-    %3 = llhd.eq %c3, %c4 : i64
+  %c1 = llhd.const 1 : i1
+  %c3 = llhd.const 3 : i64
+  %c4 = llhd.const 4 : i64
+  %0 = llhd.eq %b, %c1 : i1
+  // CHECK-NEXT: %[[VAL_3:.*]] = llhd.const true : i1
+  %1 = llhd.eq %a, %a : i64
+  %2 = llhd.eq %tup, %tup : tuple<i1, i2, i3>
+  // CHECK-NEXT: %[[VAL_4:.*]] = llhd.const false : i1
+  %3 = llhd.eq %c3, %c4 : i64
 
-    // CHECK-NEXT: return %[[VAL_1]], %[[VAL_3]], %[[VAL_3]], %[[VAL_4]] : i1, i1, i1, i1
-    return %0, %1, %2, %3 : i1, i1, i1, i1
+  // CHECK-NEXT: return %[[VAL_1]], %[[VAL_3]], %[[VAL_3]], %[[VAL_4]] : i1, i1, i1, i1
+  return %0, %1, %2, %3 : i1, i1, i1, i1
 }
 
 // CHECK-LABEL: @check_neq_folding
@@ -51,16 +51,16 @@ func @check_eq_folding(%a : i64, %b : i1, %tup : tuple<i1, i2, i3>) -> (i1, i1, 
 // CHECK-SAME:  %[[VAL_1:.*]]: i1,
 // CHECK-SAME:  %[[VAL_2:.*]]: tuple<i1, i2, i3>
 func @check_neq_folding(%a : i64, %b : i1, %tup : tuple<i1, i2, i3>) -> (i1, i1, i1, i1) {
-    %c0 = llhd.const 0 : i1
-    %c3 = llhd.const 3 : i64
-    %c4 = llhd.const 4 : i64
-    %0 = llhd.neq %b, %c0 : i1
-    // CHECK-NEXT: %[[VAL_3:.*]] = llhd.const false : i1
-    %1 = llhd.neq %a, %a : i64
-    %2 = llhd.neq %tup, %tup : tuple<i1, i2, i3>
-    // CHECK-NEXT: %[[VAL_4:.*]] = llhd.const true : i1
-    %3 = llhd.neq %c3, %c4 : i64
+  %c0 = llhd.const 0 : i1
+  %c3 = llhd.const 3 : i64
+  %c4 = llhd.const 4 : i64
+  %0 = llhd.neq %b, %c0 : i1
+  // CHECK-NEXT: %[[VAL_3:.*]] = llhd.const false : i1
+  %1 = llhd.neq %a, %a : i64
+  %2 = llhd.neq %tup, %tup : tuple<i1, i2, i3>
+  // CHECK-NEXT: %[[VAL_4:.*]] = llhd.const true : i1
+  %3 = llhd.neq %c3, %c4 : i64
 
-    // CHECK-NEXT: return %[[VAL_1]], %[[VAL_3]], %[[VAL_3]], %[[VAL_4]] : i1, i1, i1, i1
-    return %0, %1, %2, %3 : i1, i1, i1, i1
+  // CHECK-NEXT: return %[[VAL_1]], %[[VAL_3]], %[[VAL_3]], %[[VAL_4]] : i1, i1, i1, i1
+  return %0, %1, %2, %3 : i1, i1, i1, i1
 }

--- a/test/Dialect/LLHD/Canonicalization/arithmetic.mlir
+++ b/test/Dialect/LLHD/Canonicalization/arithmetic.mlir
@@ -1,0 +1,66 @@
+// RUN: circt-opt %s -mlir-print-op-generic -canonicalize | circt-opt | circt-opt | FileCheck %s
+
+// CHECK-LABEL: @check_neg_folding
+func @check_neg_folding() -> (i16) {
+    // CHECK-NEXT: %[[NEG:.*]] = llhd.const -5 : i16
+    %a = llhd.const 5 : i16
+    %0 = llhd.neg %a : i16
+
+    // CHECK-NEXT: return %[[NEG]] : i16
+    return %0 : i16
+}
+
+// CHECK-LABEL: @check_smod_folding
+// CHECK-SAME: %[[VAL_0:.*]]: i64
+func @check_smod_folding(%a : i64) -> (i64, i64, i64) {
+    %c0 = llhd.const 0 : i64
+    %c1 = llhd.const 1 : i64
+    %c9 = llhd.const 9 : i64
+    %cn5 = llhd.const -5 : i64
+    // CHECK-NEXT: %[[VAL_1:.*]] = llhd.const 0 : i64
+    %0 = llhd.smod %a, %c1 : i64
+    %1 = llhd.smod %c0, %a : i64
+    // CHECK-NEXT: %[[VAL_2:.*]] = llhd.const -1 : i64
+    %2 = llhd.smod %c9, %cn5 : i64
+
+    // CHECK-NEXT: return %[[VAL_1]], %[[VAL_1]], %[[VAL_2]] : i64, i64, i64
+    return %0, %1, %2 : i64, i64, i64
+}
+
+// CHECK-LABEL: @check_eq_folding
+// CHECK-SAME: %[[VAL_0:.*]]: i64,
+// CHECK-SAME: %[[VAL_1:.*]]: i1,
+// CHECK-SAME: %[[VAL_2:.*]]: tuple<i1, i2, i3>
+func @check_eq_folding(%a : i64, %b : i1, %tup : tuple<i1, i2, i3>) -> (i1, i1, i1, i1) {
+    %c1 = llhd.const 1 : i1
+    %c3 = llhd.const 3 : i64
+    %c4 = llhd.const 4 : i64
+    %0 = llhd.eq %b, %c1 : i1
+    // CHECK-NEXT: %[[VAL_3:.*]] = llhd.const true : i1
+    %1 = llhd.eq %a, %a : i64
+    %2 = llhd.eq %tup, %tup : tuple<i1, i2, i3>
+    // CHECK-NEXT: %[[VAL_4:.*]] = llhd.const false : i1
+    %3 = llhd.eq %c3, %c4 : i64
+
+    // CHECK-NEXT: return %[[VAL_1]], %[[VAL_3]], %[[VAL_3]], %[[VAL_4]] : i1, i1, i1, i1
+    return %0, %1, %2, %3 : i1, i1, i1, i1
+}
+
+// CHECK-LABEL: @check_neq_folding
+// CHECK-SAME:  %[[VAL_0:.*]]: i64,
+// CHECK-SAME:  %[[VAL_1:.*]]: i1,
+// CHECK-SAME:  %[[VAL_2:.*]]: tuple<i1, i2, i3>
+func @check_neq_folding(%a : i64, %b : i1, %tup : tuple<i1, i2, i3>) -> (i1, i1, i1, i1) {
+    %c0 = llhd.const 0 : i1
+    %c3 = llhd.const 3 : i64
+    %c4 = llhd.const 4 : i64
+    %0 = llhd.neq %b, %c0 : i1
+    // CHECK-NEXT: %[[VAL_3:.*]] = llhd.const false : i1
+    %1 = llhd.neq %a, %a : i64
+    %2 = llhd.neq %tup, %tup : tuple<i1, i2, i3>
+    // CHECK-NEXT: %[[VAL_4:.*]] = llhd.const true : i1
+    %3 = llhd.neq %c3, %c4 : i64
+
+    // CHECK-NEXT: return %[[VAL_1]], %[[VAL_3]], %[[VAL_3]], %[[VAL_4]] : i1, i1, i1, i1
+    return %0, %1, %2, %3 : i1, i1, i1, i1
+}

--- a/test/Dialect/LLHD/IR/arithmetic.mlir
+++ b/test/Dialect/LLHD/IR/arithmetic.mlir
@@ -1,12 +1,29 @@
-//RUN: circt-opt %s | circt-opt | FileCheck %s
+// RUN: circt-opt %s -mlir-print-op-generic | circt-opt | circt-opt | FileCheck %s
 
-// CHECK: func @check_arithmetic(%[[A:.*]]: i64, %[[B:.*]]: i64) {
-func @check_arithmetic(%a : i64, %b : i64) -> () {
+// CHECK-LABEL: @check_arithmetic
+// CHECK-SAME: %[[A:.*]]: i64
+// CHECK-SAME: %[[VEC:.*]]: vector<3xi32>
+// CHECK-SAME: %[[TUP:.*]]: tuple<i1, i2, i3>
+func @check_arithmetic(%a : i64, %vec : vector<3xi32>, %tup : tuple<i1, i2, i3>) -> () {
     // CHECK-NEXT: %{{.*}} = llhd.neg %[[A]] : i64
-    %0 = "llhd.neg"(%a) : (i64) -> i64
+    %0 = llhd.neg %a : i64
 
-    // CHECK-NEXT: %{{.*}} = llhd.smod %[[A]], %[[B]] : i64
-    %2 = "llhd.smod"(%a, %b) : (i64, i64) -> i64
+    // CHECK-NEXT: %{{.*}} = llhd.smod %[[A]], %[[A]] : i64
+    %1 = llhd.smod %a, %a : i64
+
+    // CHECK-NEXT: %{{.*}} = llhd.neq %[[A]], %[[A]] : i64
+    %2 = llhd.neq %a, %a : i64
+    // CHECK-NEXT: %{{.*}} = llhd.neq %[[VEC]], %[[VEC]] : vector<3xi32>
+    %3 = llhd.neq %vec, %vec : vector<3xi32>
+    // CHECK-NEXT: %{{.*}} = llhd.neq %[[TUP]], %[[TUP]] : tuple<i1, i2, i3>
+    %4 = llhd.neq %tup, %tup : tuple<i1, i2, i3>
+
+    // CHECK-NEXT: %{{.*}} = llhd.eq %[[A]], %[[A]] : i64
+    %5 = llhd.eq %a, %a : i64
+    // CHECK-NEXT: %{{.*}} = llhd.eq %[[VEC]], %[[VEC]] : vector<3xi32>
+    %6 = llhd.eq %vec, %vec : vector<3xi32>
+    // CHECK-NEXT: %{{.*}} = llhd.eq %[[TUP]], %[[TUP]] : tuple<i1, i2, i3>
+    %7 = llhd.eq %tup, %tup : tuple<i1, i2, i3>
 
     return
 }


### PR DESCRIPTION
* We currently use CmpIOp from the standard dialect for comparisons,
however, llhd needs to be able to compare more complex types than CmpIOp
is able to, namely tuples and in the future also logic values, etc.
* CmpIOp will still be used for relational comparisons (greater than,
less than, etc.), but should not be used for equality and inequality
anymore.