### PR TITLE
[LLHD] Add array type and array_uniform operation

### DIFF
--- a/include/circt/Dialect/LLHD/IR/LLHD.td
+++ b/include/circt/Dialect/LLHD/IR/LLHD.td
@@ -47,6 +47,9 @@ def LLHD_AnySigUnderlyingType :
 
 def LLHD_AnySigType : LLHD_SigType<[LLHD_AnySigUnderlyingType]>;
 
+// LLHD Array Type
+def LLHD_ArrayType : Type<CPred<"$_self.isa<ArrayType>()">, "LLHD array type">;
+
 //===----------------------------------------------------------------------===//
 // LLDH attribute definitions
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/LLHD/IR/LLHDDialect.h
+++ b/include/circt/Dialect/LLHD/IR/LLHDDialect.h
@@ -15,6 +15,7 @@ namespace llhd {
 namespace detail {
 struct SigTypeStorage;
 struct TimeAttrStorage;
+struct ArrayTypeStorage;
 } // namespace detail
 
 class LLHDDialect : public Dialect {
@@ -48,8 +49,13 @@ namespace LLHDTypes {
 enum Kinds {
   Sig = mlir::Type::FIRST_PRIVATE_EXPERIMENTAL_0_TYPE,
   Time,
+  Array,
 };
 } // namespace LLHDTypes
+
+//===----------------------------------------------------------------------===//
+// SigType
+//===----------------------------------------------------------------------===//
 
 class SigType
     : public mlir::Type::TypeBase<SigType, mlir::Type, detail::SigTypeStorage> {
@@ -69,6 +75,10 @@ public:
   static llvm::StringRef getKeyword() { return "sig"; }
 };
 
+//===----------------------------------------------------------------------===//
+// TimeType
+//===----------------------------------------------------------------------===//
+
 class TimeType : public Type::TypeBase<TimeType, Type, DefaultTypeStorage> {
 public:
   using Base::Base;
@@ -81,6 +91,40 @@ public:
 
   /// Get the keyword for the time type
   static llvm::StringRef getKeyword() { return "time"; }
+};
+
+//===----------------------------------------------------------------------===//
+// ArrayType
+//===----------------------------------------------------------------------===//
+
+class ArrayType
+    : public Type::TypeBase<ArrayType, Type, detail::ArrayTypeStorage> {
+public:
+  using Base::Base;
+
+  /// Get or create a new ArrayType of the provided length and element type.
+  /// Assumes the arguments define a well-formed ArrayType.
+  static ArrayType get(unsigned length, Type elementType);
+
+  /// Get or create a new ArrayType of the provided length and element type
+  /// declared at the given, potentially unknown, location. If the ArrayType
+  /// defined by the arguments would be ill-formed, emit errors and return
+  /// nullptr-wrapping type.
+  static ArrayType getChecked(unsigned length, Type elementType,
+                              Location location);
+
+  /// Verify the construction of an array type.
+  static LogicalResult
+  verifyConstructionInvariants(Location loc, unsigned length, Type elementType);
+
+  unsigned getLength() const;
+  Type getElementType() const;
+
+  /// Methods for support type inquiry through isa, cast, and dyn_cast.
+  static bool kindof(unsigned kind) { return kind == LLHDTypes::Array; }
+
+  /// Get the keyword for the array type
+  static llvm::StringRef getKeyword() { return "array"; }
 };
 
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/LLHD/IR/ValueOps.td
+++ b/include/circt/Dialect/LLHD/IR/ValueOps.td
@@ -66,6 +66,32 @@ def LLHD_VecOp : LLHD_Op<"vec", [
   let assemblyFormat = "$values attr-dict `:` type($result)";
 }
 
+def LLHD_ArrayUniformOp : LLHD_Op<"array_uniform", [
+    NoSideEffect,
+    TypesMatchWith<
+      "type of 'init' has to match the element type of the 'result' array",
+      "result", "init",
+      "$_self.cast<llhd::ArrayType>().getElementType()">
+  ]> {
+  let summary = "Create a uniform array from an initialization value.";
+  let description = [{
+    The `llhd.array_uniform` operation allows to create an LLHD array from a
+    single SSA-value used as initialization for all elements.
+
+    Example:
+
+    ```mlir
+    %init = llhd.const 1 : i32
+    %array = llhd.array_uniform %init : !llhd.array<3xi32>
+    ```
+  }];
+
+  let arguments = (ins AnyType: $init);
+  let results = (outs LLHD_ArrayType: $result);
+
+  let assemblyFormat = "$init attr-dict `:` type($result)";
+}
+
 def LLHD_TupleOp : LLHD_Op<"tuple", [
     NoSideEffect,
     TypesMatchWith<

--- a/lib/Dialect/LLHD/IR/LLHDDialect.cpp
+++ b/lib/Dialect/LLHD/IR/LLHDDialect.cpp
@@ -101,11 +101,6 @@ static Type parseArrayType(DialectAsmParser &parser) {
                      "Array must have exactly one dimension");
     return nullptr;
   }
-  if (length[0] < 0) {
-    parser.emitError(parser.getCurrentLocation(),
-                     "Array length must be non-negative");
-    return nullptr;
-  }
   return ArrayType::get(length[0], elementType);
 }
 

--- a/lib/Dialect/LLHD/IR/LLHDDialect.cpp
+++ b/lib/Dialect/LLHD/IR/LLHDDialect.cpp
@@ -47,7 +47,7 @@ struct LLHDInlinerInterface : public DialectInlinerInterface {
 
 LLHDDialect::LLHDDialect(mlir::MLIRContext *context)
     : Dialect(getDialectNamespace(), context) {
-  addTypes<SigType, TimeType>();
+  addTypes<SigType, TimeType, ArrayType>();
   addAttributes<TimeAttr>();
   addOperations<
 #define GET_OP_LIST
@@ -84,6 +84,31 @@ static Type parseSigType(DialectAsmParser &parser) {
   return SigType::get(underlyingType);
 }
 
+/// Parse an array type.
+/// Syntax: array ::= !llhd.array<{length}x{elementType}>
+static Type parseArrayType(DialectAsmParser &parser) {
+  Type elementType;
+  SmallVector<int64_t, 1> length;
+  if (parser.parseLess() || parser.parseDimensionList(length, false) ||
+      parser.parseType(elementType) || parser.parseGreater()) {
+    parser.emitError(parser.getCurrentLocation(),
+                     "No array type found. Array needs a length and an element "
+                     "type.");
+    return nullptr;
+  }
+  if (length.size() != 1) {
+    parser.emitError(parser.getCurrentLocation(),
+                     "Array must have exactly one dimension");
+    return nullptr;
+  }
+  if (length[0] < 0) {
+    parser.emitError(parser.getCurrentLocation(),
+                     "Array length must be non-negative");
+    return nullptr;
+  }
+  return ArrayType::get(length[0], elementType);
+}
+
 Type LLHDDialect::parseType(DialectAsmParser &parser) const {
   llvm::StringRef typeKeyword;
   // parse the type keyword first
@@ -94,6 +119,8 @@ Type LLHDDialect::parseType(DialectAsmParser &parser) const {
   }
   if (typeKeyword == TimeType::getKeyword())
     return TimeType::get(getContext());
+  if (typeKeyword == ArrayType::getKeyword())
+    return parseArrayType(parser);
   return Type();
 }
 
@@ -112,6 +139,9 @@ void LLHDDialect::printType(Type type, DialectAsmPrinter &printer) const {
     printSigType(sig, printer);
   } else if (TimeType time = type.dyn_cast<TimeType>()) {
     printer << time.getKeyword();
+  } else if (ArrayType array = type.dyn_cast<ArrayType>()) {
+    printer << array.getKeyword() << "<" << array.getLength() << "x"
+            << array.getElementType() << ">";
   }
 }
 
@@ -225,6 +255,31 @@ private:
   mlir::Type underlyingType;
 };
 
+/// Array Type Storage and Uniquing.
+struct ArrayTypeStorage : public TypeStorage {
+  /// The hash key used for uniquing.
+  using KeyTy = std::pair<unsigned, Type>;
+  ArrayTypeStorage(unsigned length, Type elementTy)
+      : length(length), elementType(elementTy) {}
+
+  bool operator==(const KeyTy &key) const {
+    return key == KeyTy(length, elementType);
+  }
+
+  static ArrayTypeStorage *construct(TypeStorageAllocator &allocator,
+                                     const KeyTy &key) {
+    return new (allocator.allocate<ArrayTypeStorage>())
+        ArrayTypeStorage(key.first, key.second);
+  }
+
+  unsigned getLength() const { return length; }
+  Type getElementType() const { return elementType; }
+
+private:
+  unsigned length;
+  Type elementType;
+};
+
 //===----------------------------------------------------------------------===//
 // Attribute storage
 //===----------------------------------------------------------------------===//
@@ -303,6 +358,30 @@ mlir::Type SigType::getUnderlyingType() {
 TimeType TimeType::get(MLIRContext *context) {
   return Base::get(context, LLHDTypes::Time);
 }
+
+// ArrayType
+
+ArrayType ArrayType::get(unsigned length, Type elementType) {
+  return Base::get(elementType.getContext(), LLHDTypes::Array, length,
+                   elementType);
+}
+
+ArrayType ArrayType::getChecked(unsigned length, Type elementType,
+                                Location location) {
+  return Base::getChecked(location, LLHDTypes::Array, length, elementType);
+}
+
+LogicalResult ArrayType::verifyConstructionInvariants(Location loc,
+                                                      unsigned length,
+                                                      Type elementType) {
+  if (length == 0)
+    return emitError(loc, "array types must have at least one element");
+
+  return success();
+}
+
+unsigned ArrayType::getLength() const { return getImpl()->getLength(); }
+Type ArrayType::getElementType() const { return getImpl()->getElementType(); }
 
 //===----------------------------------------------------------------------===//
 // LLHD Attribtues

--- a/test/Dialect/LLHD/IR/vec.mlir
+++ b/test/Dialect/LLHD/IR/vec.mlir
@@ -12,4 +12,19 @@ func @check_vec(%c1 : i1, %c2 : i1, %c3 : i1, %c4 : i32, %c5 : i32, %c6 : i32) {
   return
 }
 
+// CHECK-LABEL: @check_array_uniform
+// CHECK-SAME: %[[C1:.*]]: i1
+// CHECK-SAME: %[[C32:.*]]: i32
+// CHECK-SAME: %[[TUP:.*]]: tuple<i1, i2, i3>
+func @check_array_uniform(%c1 : i1, %c32 : i32, %tup : tuple<i1, i2, i3>) {
+  // CHECK-NEXT: %{{.*}} = llhd.array_uniform %[[C1]] : !llhd.array<50xi1>
+  %0 = llhd.array_uniform %c1 : !llhd.array<50xi1>
+  // CHECK-NEXT: %{{.*}} = llhd.array_uniform %[[C32]] : !llhd.array<1xi32>
+  %1 = llhd.array_uniform %c32 : !llhd.array<1xi32>
+  // CHECK-NEXT: %{{.*}} = llhd.array_uniform %[[TUP]] : !llhd.array<5xtuple<i1, i2, i3>>
+  %3 = llhd.array_uniform %tup : !llhd.array<5xtuple<i1, i2, i3>>
+
+  return
+}
+
 // TODO: add more tests


### PR DESCRIPTION
* The MLIR vector type is limited to integer and float element types,
however, it should be possible to represent vectors of tuples in LLHD.
The moore compiler also creates those for certain SystemVerilog designs.
* Add a simple array_uniform operation to create this type, also as a
replacement for the vector.broadcast operation
* The vector type will be replaced by this new array type in all other
operations in a future commit.